### PR TITLE
Fix nginx resolver for API proxy

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -3,6 +3,9 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Docker's embedded DNS resolver — required for runtime hostname resolution.
+    resolver 127.0.0.11 valid=10s ipv6=off;
+
     # SPA — serve index.html for all non-file routes
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## Summary

Add `resolver 127.0.0.11` (Docker embedded DNS) to nginx config. Without it, variable-based `proxy_pass` can't resolve hostnames at request time, causing all `/v1/` API calls to fail.

## Test plan

- [ ] Admin panel loads schemas at `localhost:3000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)