### PR TITLE
Fix: separate browser API URL from nginx proxy URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ EXPOSE 80
 
 # Runtime env vars (overridable)
 ENV API_URL="http://localhost:8080"
+ENV BROWSER_API_URL=""
 ENV LAYOUT_MODE="full"
 ENV TENANT_ID=""
 ENV SCHEMA_ID=""

--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -9,10 +9,15 @@ set -e
 
 CONFIG_DIR="/usr/share/nginx/html"
 
-# Build a runtime config object from environment variables
+# BROWSER_API_URL is what the browser uses for API calls.
+# Default: empty = same origin (browser hits nginx, nginx proxies to API_URL).
+# Only set BROWSER_API_URL if the browser should call the API directly (e.g., no proxy).
+#
+# API_URL is used by nginx for reverse proxying /v1/ requests (Docker-internal hostname).
+
 cat > "$CONFIG_DIR/config.js" <<EOF
 window.__DECREE_UI_CONFIG__ = {
-  apiUrl: "${API_URL}",
+  apiUrl: "${BROWSER_API_URL}",
   layoutMode: "${LAYOUT_MODE:-full}",
   tenantId: "${TENANT_ID}",
   schemaId: "${SCHEMA_ID}"


### PR DESCRIPTION
## Summary

- Add `BROWSER_API_URL` env var (default: empty = same origin)
- `API_URL` is now only used by nginx `proxy_pass` (Docker-internal hostname)
- `BROWSER_API_URL` is what the browser's JS uses for API calls

**The bug:** `API_URL=http://decree-server:8080` was injected into `config.js`, causing the browser to try resolving `decree-server` — a Docker-internal hostname not reachable from the host.

**The fix:** Browser uses empty `apiUrl` → requests go to same origin (`localhost:3000`) → nginx proxies `/v1/` to `API_URL`.

## Test plan

- [x] `config.js` shows `apiUrl: ""` when only `API_URL` is set
- [ ] Admin panel loads schemas at `localhost:3000` (needs full stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)