### PR TITLE
docs: Dockerfile env var comments + config.ts default clarification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,19 @@ RUN chmod +x /docker-entrypoint.d/40-env-config.sh
 
 EXPOSE 80
 
-# Runtime env vars (overridable)
+# Runtime env vars (overridable).
+# See docs/ui-modes.md for full documentation of modes and personas.
 ENV API_URL="http://localhost:8080"
+# Backend URL for nginx reverse proxy (Docker-internal hostname).
 ENV BROWSER_API_URL=""
+# Browser API URL. Empty = same-origin (nginx proxies /v1/ to API_URL).
 ENV LAYOUT_MODE="full"
+# UI mode: full, single-tenant, single-schema. See docs/ui-modes.md.
 ENV TENANT_ID=""
+# Pre-selected tenant UUID or name slug. Required for single-tenant mode.
 ENV SCHEMA_ID=""
+# Pre-selected schema UUID or name slug. Required for single-schema mode.
 ENV DEFAULT_ROLE=""
+# Default auth role: superadmin, admin, user. Empty = superadmin.
 ENV DEFAULT_SUBJECT=""
+# Default auth subject identity. Empty = "admin".

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -28,9 +28,9 @@ export const config = {
 	/** Pre-selected schema ID for single-schema mode. */
 	schemaId: runtime.schemaId || (import.meta.env.VITE_SCHEMA_ID as string | undefined),
 
-	/** Default role for auth headers. */
+	/** Default role for auth headers. Empty = superadmin (see constants.ts). */
 	defaultRole: runtime.defaultRole || import.meta.env.VITE_DEFAULT_ROLE || "",
 
-	/** Default subject for auth headers. */
+	/** Default subject for auth headers. Empty = "admin" (see constants.ts). */
 	defaultSubject: runtime.defaultSubject || import.meta.env.VITE_DEFAULT_SUBJECT || "",
 } as const;


### PR DESCRIPTION
Doc fix — inline comments on all Dockerfile ENV lines, clarify empty-string defaults in config.ts.