### PR TITLE
fix(ui): invalidate versions cache after config apply

### DIFF
--- a/src/pages/tenants/TenantDetail.tsx
+++ b/src/pages/tenants/TenantDetail.tsx
@@ -218,6 +218,7 @@ export function TenantDetail() {
 			setApplyError(null);
 			setEditing(false);
 			queryClient.invalidateQueries({ queryKey: ["config", tid] });
+			queryClient.invalidateQueries({ queryKey: ["versions", tid] });
 		},
 		onError: (err: Error) => setApplyError(err.message),
 	});


### PR DESCRIPTION
## Summary
- Apply mutation only invalidated `["config", tid]` — History page stayed stale after config edit until manual refresh
- Added `["versions", tid]` invalidation on success, matching rollback/import paths

Fixes #17

## Test plan
- [x] biome check clean
- [x] tsc --noEmit clean
- [x] vitest passes
- [x] build passes
- [ ] Manual: edit config → apply → navigate to History → latest version shows without refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)