### PR TITLE
ci: YAML anchors for Node.js setup (evaluate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@
 #
 # Jobs: lint, typecheck, test, build → check (alls-green gate)
 # The check job aggregates all results for branch protection.
+#
+# The first job defines YAML anchors (&checkout, &setup-node-22, &install)
+# on its setup steps; subsequent jobs alias them to avoid repetition.
 
 name: CI
 
@@ -16,20 +19,20 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - &checkout
+        name: Checkout
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-
-      - name: Set up Node.js
+      - &setup-node-22
+        name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
-
-      - name: Install dependencies
+      - &install
+        name: Install dependencies
         run: npm ci
-
       - name: Run biome lint
         run: npm run lint
 
@@ -37,20 +40,9 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
+      - *checkout
+      - *setup-node-22
+      - *install
       - name: Run tsc
         run: npm run typecheck
 
@@ -58,20 +50,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
+      - *checkout
+      - *setup-node-22
+      - *install
       - name: Run tests
         run: npm test
 
@@ -79,20 +60,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
+      - *checkout
+      - *setup-node-22
+      - *install
       - name: Build production bundle
         run: npm run build
 


### PR DESCRIPTION
## Summary
- Dedupe `checkout + setup-node@22 + npm ci` across lint/typecheck/test/build via YAML anchors
- Anchors defined on first job's steps (&checkout, &setup-node-22, &install), aliased by subsequent jobs
- Zero behavior change, -30 net lines (108 → 77)

## Evaluation
Part of the "evaluate YAML anchor support stability" acceptance criterion in opendecree/decree#11. CI pass on this PR = anchors work; we apply the same pattern to decree-typescript next.

## Test plan
- [ ] CI green: lint, typecheck, test, build, check all pass
- [ ] Each job's expanded step list matches pre-refactor (verified locally via `yaml.safe_load`)

Relates to opendecree/decree#11

🤖 Generated with [Claude Code](https://claude.com/claude-code)