### PR TITLE
feat(screenshots): add data-testid anchors to deterministically wait for page load

### DIFF
--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -28,9 +28,13 @@ PNGs land in this directory — one per page, per color scheme (`light-*` and `d
 
 ## Contract
 
-The script looks up fixture IDs by `name` via `GET /v1/schemas` and `GET /v1/tenants`, so the
-committed fixture names (`billing`, `showcase`, `acme`, `demo`) must stay stable. Renaming a
-fixture means updating `scripts/screenshots.ts` in the same change.
+Two things the script depends on — don't break them without updating `scripts/screenshots.ts`:
+
+1. **Fixture names** (`billing`, `showcase`, `acme`, `demo`) — resolved to UUIDs via `GET /v1/schemas`
+   and `GET /v1/tenants`. Names are stable across seed runs; UUIDs are not.
+2. **Page root `data-testid` anchors** — used to wait for the page to render before snapping, so
+   screenshots don't capture loading spinners. Anchors in use:
+   - `home-page`, `schema-list-page`, `schema-detail-page`, `tenant-list-page`, `tenant-detail-page`
 
 ## Environment
 

--- a/scripts/screenshots.ts
+++ b/scripts/screenshots.ts
@@ -42,7 +42,9 @@ async function fetchNameMap(path: string, key: "schemas" | "tenants"): Promise<M
 interface ScreenshotPage {
 	name: string;
 	path: string;
-	/** Extra wait time in ms for async data to load. */
+	/** data-testid on the page root — waited for before snapping. */
+	testId?: string;
+	/** Extra wait time in ms for async data to settle after the testid appears. */
 	wait?: number;
 }
 
@@ -59,14 +61,14 @@ function buildPages(schemas: Map<string, string>, tenants: Map<string, string>):
 	const demo = need(tenants, "demo", "tenant");
 
 	return [
-		{ name: "home", path: "/" },
-		{ name: "schemas", path: "/schemas" },
-		{ name: "schema-billing", path: `/schemas/${billing}`, wait: 500 },
-		{ name: "schema-showcase", path: `/schemas/${showcase}`, wait: 500 },
+		{ name: "home", path: "/", testId: "home-page" },
+		{ name: "schemas", path: "/schemas", testId: "schema-list-page" },
+		{ name: "schema-billing", path: `/schemas/${billing}`, testId: "schema-detail-page", wait: 300 },
+		{ name: "schema-showcase", path: `/schemas/${showcase}`, testId: "schema-detail-page", wait: 300 },
 		{ name: "schema-import", path: "/schemas/import" },
-		{ name: "tenants", path: "/tenants" },
-		{ name: "tenant-demo", path: `/tenants/${demo}`, wait: 500 },
-		{ name: "tenant-acme", path: `/tenants/${acme}`, wait: 500 },
+		{ name: "tenants", path: "/tenants", testId: "tenant-list-page" },
+		{ name: "tenant-demo", path: `/tenants/${demo}`, testId: "tenant-detail-page", wait: 300 },
+		{ name: "tenant-acme", path: `/tenants/${acme}`, testId: "tenant-detail-page", wait: 300 },
 		{ name: "tenant-create", path: "/tenants/create", wait: 500 },
 		{ name: "audit-demo", path: `/tenants/${demo}/audit`, wait: 500 },
 		{ name: "usage-demo", path: `/tenants/${demo}/usage`, wait: 500 },
@@ -102,6 +104,7 @@ async function main() {
 			const url = `${BASE_URL}${p.path}`;
 			console.log(`${mode}/${p.name}: ${url}`);
 			await page.goto(url, { waitUntil: "networkidle" });
+			if (p.testId) await page.getByTestId(p.testId).waitFor({ state: "visible" });
 			if (p.wait) await page.waitForTimeout(p.wait);
 			await page.screenshot({ path: `${OUT_DIR}/${mode}-${p.name}.png`, fullPage: true });
 		}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -17,7 +17,7 @@ export function Home() {
 	});
 
 	return (
-		<div className="mx-auto max-w-2xl">
+		<div className="mx-auto max-w-2xl" data-testid="home-page">
 			<h2 className="mb-6 text-2xl font-semibold">{label("app.title")}</h2>
 
 			{version && (

--- a/src/pages/schemas/SchemaDetail.tsx
+++ b/src/pages/schemas/SchemaDetail.tsx
@@ -65,7 +65,7 @@ export function SchemaDetail() {
 	};
 
 	return (
-		<div>
+		<div data-testid="schema-detail-page">
 			<div className="mb-6">
 				<Link to="/schemas" className="text-sm text-blue-600 hover:underline dark:text-blue-400">
 					&larr; {label("common.back")} to {label("schema.plural").toLowerCase()}

--- a/src/pages/schemas/SchemaList.tsx
+++ b/src/pages/schemas/SchemaList.tsx
@@ -17,7 +17,7 @@ export function SchemaList() {
 		: schemas;
 
 	return (
-		<div>
+		<div data-testid="schema-list-page">
 			<div className="mb-6 flex items-center justify-between">
 				<h2 className="text-xl font-semibold">{label("schema.plural")}</h2>
 				{canManageSchemas(auth.role) && (

--- a/src/pages/tenants/TenantDetail.tsx
+++ b/src/pages/tenants/TenantDetail.tsx
@@ -260,7 +260,10 @@ export function TenantDetail() {
 	const isLoading = tenantLoading || schemaLoading || configLoading;
 
 	return (
-		<div className={editing && pendingChanges.size > 0 ? "pb-24" : ""}>
+		<div
+			className={editing && pendingChanges.size > 0 ? "pb-24" : ""}
+			data-testid="tenant-detail-page"
+		>
 			{appConfig.layoutMode !== "single-tenant" && (
 				<div className="mb-6">
 					<Link to="/tenants" className="text-sm text-blue-600 hover:underline dark:text-blue-400">

--- a/src/pages/tenants/TenantList.tsx
+++ b/src/pages/tenants/TenantList.tsx
@@ -26,7 +26,7 @@ export function TenantList() {
 		: tenants;
 
 	return (
-		<div>
+		<div data-testid="tenant-list-page">
 			<div className="mb-6 flex items-center justify-between">
 				<h2 className="text-xl font-semibold">{label("tenant.plural")}</h2>
 				{canManageTenants(auth.role) && (


### PR DESCRIPTION
## Summary

- Add `data-testid` on 5 page roots so the screenshot script can deterministically wait for each page to finish rendering before snapping — no more flaked captures of loading spinners under a busy dev machine.
- Update `scripts/screenshots.ts` to use `page.getByTestId(...).waitFor()` before the fixed timeout.
- Document the testid contract in `docs/screenshots/README.md` so future refactors of these pages don't silently break the screenshot flow.

## Anchors

`home-page`, `schema-list-page`, `schema-detail-page`, `tenant-list-page`, `tenant-detail-page`.

Pages without anchors (schema-import, tenant-create, audit, usage) still use the timeout-only wait — those are lower-priority screens where flake is acceptable.

## Test plan

- [ ] `npm run pre-commit` clean (biome + tsc + vitest + build)
- [ ] With backend seeded, `npm run screenshots` produces all 22 PNGs
- [ ] Introducing a rename of any anchor (e.g. `home-page` → `home-root`) makes the script fail loudly, not silently

Refs #33