### PR TITLE
docs: add SECURITY.md referencing GitHub advisory form

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in the OpenDecree Admin GUI, please report it responsibly.
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, please [report it via GitHub Security Advisories](https://github.com/opendecree/decree-ui/security/advisories/new).
+
+You should receive a response within 48 hours. We will work with you to understand and address the issue before any public disclosure.
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| latest  | Yes       |
+
+## Scope
+
+This policy covers the Admin GUI in this repository. For issues in the core service, CLI, or SDKs, please report to the [main repository](https://github.com/opendecree/decree).


### PR DESCRIPTION
## Summary
- Add \`SECURITY.md\` pointing reporters to the GitHub Security Advisory form
- Mirrors the policy in decree, decree-python, decree-typescript, demos

Part of opendecree/decree#151 — private vulnerability reporting is now enabled on this repo.

## Test plan
- [ ] SECURITY.md renders on GitHub
- [ ] "Report a vulnerability" button on repo Security tab works

🤖 Generated with [Claude Code](https://claude.com/claude-code)