### PR TITLE
docs: add repostatus alpha badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/opendecree/decree-ui/actions/workflows/ci.yml/badge.svg)](https://github.com/opendecree/decree-ui/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/opendecree/decree-ui)](LICENSE)
+[![Project Status: WIP](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 
 Web-based admin interface for [OpenDecree](https://github.com/opendecree/decree) — schema-driven configuration management.
 


### PR DESCRIPTION
## Summary
- Adds [repostatus.org](https://www.repostatus.org/) **WIP** badge alongside existing CI and license badges.
- Completes AC for decree-ui in opendecree/decree#146.

## Test plan
- [ ] README renders correctly on GitHub
- [ ] Badge links to repostatus.org/#wip