### PR TITLE
docs: add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+
+
+## Related issues
+
+Closes #
+
+## Test plan
+
+- [ ] `npm run lint` passes
+- [ ] `npm run typecheck` passes
+- [ ] `npm test` passes
+- [ ] `npm run build` passes
+- [ ] Manually verified in browser (if UI behavior changed)
+
+## Checklist
+
+- [ ] OpenAPI types regenerated (`npm run generate`) if `decree` API changed
+- [ ] Breaking change flagged in title/description if applicable
+- [ ] Screenshots updated if visual changes


### PR DESCRIPTION
## Summary

Add `.github/PULL_REQUEST_TEMPLATE.md`. decree-ui was the only repo without one.

## Related issues

Refs opendecree/decree#154

## Test plan

- [x] Template renders on PR creation (verify on this PR)