### PR TITLE
[Fix] Keep header balanced when AuthBar is hidden

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -133,6 +133,7 @@ export function Layout() {
 	const hasTenantScope = !isSuperadmin && auth.tenantId;
 	const tenantPath = auth.tenantId ? `/tenants/${auth.tenantId}` : "/";
 
+	const showAuthBar = import.meta.env.VITE_HIDE_DEBUG !== "1";
 	const appName = config.appName || label("app.name");
 	const logoSrc = config.logoUrl || "/logo.svg";
 
@@ -204,7 +205,7 @@ export function Layout() {
 			<div className="flex flex-1 flex-col overflow-hidden">
 				{/* Header */}
 				<header className="flex items-center justify-between border-b border-gray-200 px-6 py-3 dark:border-gray-800">
-					<AuthBar />
+					{showAuthBar ? <AuthBar /> : <div className="flex-1" />}
 					<DarkModeToggle />
 				</header>
 


### PR DESCRIPTION
## Summary

Fixes opendecree/decree-ui#48 — Dark mode toggle floats alone when debug bar is hidden.

## Changes

- Added `showAuthBar` flag based on `VITE_HIDE_DEBUG` env var
- When AuthBar is hidden (`VITE_HIDE_DEBUG=1`), a `flex-1` spacer keeps the header layout balanced
- Dark mode toggle stays anchored to the right in both modes

## Before
When `VITE_HIDE_DEBUG=1`: header has empty left side + toggle on right → looks unbalanced.

## After
Toggle stays on the right, spacer fills the left → balanced layout in both modes.