### PR TITLE
feat(ui): implement global toast notification system

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { Layout } from "./components/Layout";
 import type { AuthState } from "./lib/auth";
 import { AuthContext, loadAuth, saveAuth } from "./lib/auth";
 import { config } from "./lib/config";
+import { ToastProvider } from "./lib/toast";
 import { Home } from "./pages/Home";
 import { NotFound } from "./pages/NotFound";
 import { SchemaDetail } from "./pages/schemas/SchemaDetail";
@@ -46,30 +47,32 @@ export function App() {
 	return (
 		<AuthContext value={{ auth, setAuth }}>
 			<QueryClientProvider client={queryClient}>
-				<Routes>
-					{/* Standard layout with sidebar + header */}
-					<Route element={<Layout />}>
-						<Route index element={<HomeOrRedirect />} />
-						<Route path="schemas" element={<SchemaList />} />
-						<Route path="schemas/import" element={<SchemaImport />} />
-						<Route path="schemas/:id" element={<SchemaDetail />} />
-						<Route path="tenants" element={<TenantList />} />
-						<Route path="tenants/create" element={<TenantCreate />} />
-						<Route path="tenants/:id" element={<TenantDetail />} />
-						<Route path="tenants/:id/history" element={<TenantHistory />} />
-						<Route path="tenants/:id/audit" element={<TenantAudit />} />
-						<Route path="tenants/:id/usage" element={<TenantUsage />} />
-						<Route path="*" element={<NotFound />} />
-					</Route>
+				<ToastProvider>
+					<Routes>
+						{/* Standard layout with sidebar + header */}
+						<Route element={<Layout />}>
+							<Route index element={<HomeOrRedirect />} />
+							<Route path="schemas" element={<SchemaList />} />
+							<Route path="schemas/import" element={<SchemaImport />} />
+							<Route path="schemas/:id" element={<SchemaDetail />} />
+							<Route path="tenants" element={<TenantList />} />
+							<Route path="tenants/create" element={<TenantCreate />} />
+							<Route path="tenants/:id" element={<TenantDetail />} />
+							<Route path="tenants/:id/history" element={<TenantHistory />} />
+							<Route path="tenants/:id/audit" element={<TenantAudit />} />
+							<Route path="tenants/:id/usage" element={<TenantUsage />} />
+							<Route path="*" element={<NotFound />} />
+						</Route>
 
-					{/* Embed layout — no sidebar, no header, for iframe use */}
-					<Route path="embed" element={<EmbedLayout />}>
-						<Route path="tenants/:id" element={<TenantDetail />} />
-						<Route path="tenants/:id/audit" element={<TenantAudit />} />
-						<Route path="tenants/:id/usage" element={<TenantUsage />} />
-						<Route path="schemas/:id" element={<SchemaDetail />} />
-					</Route>
-				</Routes>
+						{/* Embed layout — no sidebar, no header, for iframe use */}
+						<Route path="embed" element={<EmbedLayout />}>
+							<Route path="tenants/:id" element={<TenantDetail />} />
+							<Route path="tenants/:id/audit" element={<TenantAudit />} />
+							<Route path="tenants/:id/usage" element={<TenantUsage />} />
+							<Route path="schemas/:id" element={<SchemaDetail />} />
+						</Route>
+					</Routes>
+				</ToastProvider>
 			</QueryClientProvider>
 		</AuthContext>
 	);

--- a/src/components/ConfigHistory.tsx
+++ b/src/components/ConfigHistory.tsx
@@ -5,6 +5,7 @@ import type { Role } from "../lib/constants";
 import { useApiClient, useAuditLog, useVersions } from "../lib/hooks";
 import { label } from "../lib/labels";
 import { canEditConfig } from "../lib/permissions";
+import { useToast } from "../lib/toast";
 import { FieldChanges } from "./FieldChanges";
 
 type ConfigVersion = components["schemas"]["v1ConfigVersion"];
@@ -19,10 +20,10 @@ interface ConfigHistoryProps {
 export function ConfigHistory({ tenantId, currentVersion, role }: ConfigHistoryProps) {
 	const client = useApiClient();
 	const queryClient = useQueryClient();
+	const { toast } = useToast();
 	const { data, isLoading } = useVersions(tenantId);
 	const versions = data?.versions ?? [];
 	const [rollbackTarget, setRollbackTarget] = useState<number | null>(null);
-	const [importError, setImportError] = useState<string | null>(null);
 	const fileInputRef = useRef<HTMLInputElement>(null);
 
 	const rollbackMutation = useMutation({
@@ -36,7 +37,9 @@ export function ConfigHistory({ tenantId, currentVersion, role }: ConfigHistoryP
 			setRollbackTarget(null);
 			queryClient.invalidateQueries({ queryKey: ["config", tenantId] });
 			queryClient.invalidateQueries({ queryKey: ["versions", tenantId] });
+			toast.success("Rolled back");
 		},
+		onError: (err: Error) => toast.error(`Rollback failed: ${err.message}`),
 	});
 
 	const handleExport = useCallback(async () => {
@@ -63,11 +66,11 @@ export function ConfigHistory({ tenantId, currentVersion, role }: ConfigHistoryP
 			if (error) throw new Error(formatError(error));
 		},
 		onSuccess: () => {
-			setImportError(null);
+			toast.success("Config imported");
 			queryClient.invalidateQueries({ queryKey: ["config", tenantId] });
 			queryClient.invalidateQueries({ queryKey: ["versions", tenantId] });
 		},
-		onError: (err: Error) => setImportError(err.message),
+		onError: (err: Error) => toast.error(`Import failed: ${err.message}`),
 	});
 
 	const handleImport = useCallback(() => {
@@ -116,10 +119,6 @@ export function ConfigHistory({ tenantId, currentVersion, role }: ConfigHistoryP
 				</div>
 			)}
 
-			{importError && (
-				<p className="mb-3 text-sm text-red-600 dark:text-red-400">Import failed: {importError}</p>
-			)}
-
 			{isLoading && (
 				<p className="text-sm text-gray-500 dark:text-gray-400">{label("common.loading")}</p>
 			)}
@@ -145,12 +144,6 @@ export function ConfigHistory({ tenantId, currentVersion, role }: ConfigHistoryP
 						/>
 					))}
 				</div>
-			)}
-
-			{rollbackMutation.isError && (
-				<p className="mt-2 text-sm text-red-600 dark:text-red-400">
-					Rollback failed: {rollbackMutation.error.message}
-				</p>
 			)}
 		</div>
 	);

--- a/src/components/PendingChangesBar.tsx
+++ b/src/components/PendingChangesBar.tsx
@@ -25,8 +25,6 @@ export interface PendingChangesBarProps {
 	onReset: () => void;
 	/** Whether the apply mutation is in progress. */
 	isApplying: boolean;
-	/** Error message from the last apply attempt. */
-	applyError: string | null;
 }
 
 /** Sticky bottom bar that appears when there are pending config changes. */
@@ -39,7 +37,6 @@ export function PendingChangesBar({
 	onApply,
 	onReset,
 	isApplying,
-	applyError,
 }: PendingChangesBarProps) {
 	const [showReview, setShowReview] = useState(false);
 	const count = pendingChanges.size;
@@ -83,12 +80,6 @@ export function PendingChangesBar({
 							className="w-full rounded border border-gray-300 bg-white px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
 						/>
 					</div>
-				</div>
-			)}
-
-			{applyError && (
-				<div className="mx-auto max-w-5xl px-6 pt-2">
-					<p className="text-sm text-red-600 dark:text-red-400">{applyError}</p>
 				</div>
 			)}
 

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useRef } from "react";
+import type { ToastItem } from "../lib/toast";
+
+interface Props {
+	toast: ToastItem;
+	onDismiss: (id: string) => void;
+	onShowDetails: (content: string | React.ReactNode) => void;
+}
+
+const ICONS: Record<string, string> = {
+	error: "✕",
+	warning: "⚠",
+	success: "✓",
+	info: "ℹ",
+};
+
+const COLORS: Record<string, { bar: string; icon: string; text: string; badge: string }> = {
+	error: {
+		bar: "bg-red-50 border-l-4 border-red-600 dark:bg-red-950 dark:border-red-500",
+		icon: "text-red-600 dark:text-red-400",
+		text: "text-gray-900 dark:text-gray-100",
+		badge: "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300",
+	},
+	warning: {
+		bar: "bg-yellow-50 border-l-4 border-yellow-600 dark:bg-yellow-950 dark:border-yellow-500",
+		icon: "text-yellow-600 dark:text-yellow-400",
+		text: "text-gray-900 dark:text-gray-100",
+		badge: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300",
+	},
+	success: {
+		bar: "bg-green-50 border-l-4 border-green-600 dark:bg-green-950 dark:border-green-500",
+		icon: "text-green-600 dark:text-green-400",
+		text: "text-gray-900 dark:text-gray-100",
+		badge: "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300",
+	},
+	info: {
+		bar: "bg-blue-50 border-l-4 border-blue-600 dark:bg-blue-950 dark:border-blue-500",
+		icon: "text-blue-600 dark:text-blue-400",
+		text: "text-gray-900 dark:text-gray-100",
+		badge: "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
+	},
+};
+
+const ARIA_ROLES: Record<string, string> = {
+	error: "alert",
+	warning: "alert",
+	success: "status",
+	info: "status",
+};
+
+function prefersReducedMotion() {
+	return (
+		typeof window.matchMedia === "function" &&
+		window.matchMedia("(prefers-reduced-motion: reduce)").matches
+	);
+}
+
+export function Toast({ toast, onDismiss, onShowDetails }: Props) {
+	const c = COLORS[toast.severity];
+	const remainingRef = useRef(toast.duration);
+	const startRef = useRef<number | null>(null);
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		if (toast.duration === 0) return;
+
+		function start() {
+			startRef.current = Date.now();
+			timerRef.current = setTimeout(() => {
+				onDismiss(toast.id);
+			}, remainingRef.current);
+		}
+
+		start();
+		return () => {
+			if (timerRef.current) clearTimeout(timerRef.current);
+		};
+	}, [toast.id, toast.duration, onDismiss]);
+
+	function handleMouseEnter() {
+		if (toast.duration === 0) return;
+		if (timerRef.current) clearTimeout(timerRef.current);
+		if (startRef.current !== null) {
+			remainingRef.current = Math.max(0, remainingRef.current - (Date.now() - startRef.current));
+		}
+	}
+
+	function handleMouseLeave() {
+		if (toast.duration === 0) return;
+		startRef.current = Date.now();
+		timerRef.current = setTimeout(() => {
+			onDismiss(toast.id);
+		}, remainingRef.current);
+	}
+
+	const motionClass = prefersReducedMotion() ? "" : "animate-[slide-in_0.2s_ease-out]";
+
+	return (
+		// biome-ignore lint/a11y/noStaticElementInteractions: hover pause is supplemental; keyboard access via close button
+		<div
+			role={ARIA_ROLES[toast.severity]}
+			className={`flex w-full max-w-sm items-start gap-3 rounded-md px-4 py-3 shadow-lg ${c.bar} ${motionClass}`}
+			onMouseEnter={handleMouseEnter}
+			onMouseLeave={handleMouseLeave}
+		>
+			<span className={`mt-0.5 shrink-0 text-sm font-bold ${c.icon}`}>{ICONS[toast.severity]}</span>
+			<div className="flex min-w-0 flex-1 flex-col gap-1">
+				<span className={`text-sm leading-snug ${c.text}`}>{toast.message}</span>
+				{toast.details !== undefined && (
+					<button
+						type="button"
+						className="self-start text-xs underline opacity-70 hover:opacity-100"
+						onClick={() => onShowDetails(toast.details)}
+					>
+						Details...
+					</button>
+				)}
+			</div>
+			{toast.count > 1 && (
+				<span className={`shrink-0 rounded-full px-1.5 py-0.5 text-xs font-semibold ${c.badge}`}>
+					×{toast.count}
+				</span>
+			)}
+			<button
+				type="button"
+				aria-label="Dismiss notification"
+				className="shrink-0 opacity-50 hover:opacity-100"
+				onClick={() => onDismiss(toast.id)}
+			>
+				<span className={`text-xs ${c.text}`}>✕</span>
+			</button>
+		</div>
+	);
+}

--- a/src/components/Toaster.tsx
+++ b/src/components/Toaster.tsx
@@ -1,0 +1,48 @@
+import { useContext } from "react";
+import { ToastContext } from "../lib/toast";
+import { SlideOver } from "./SlideOver";
+import { Toast } from "./Toast";
+
+export function Toaster() {
+	const { toasts, dismiss, dismissAll, detailsOpen, detailsContent, openDetails, closeDetails } =
+		useContext(ToastContext);
+
+	if (toasts.length === 0 && !detailsOpen) return null;
+
+	return (
+		<>
+			{toasts.length > 0 && (
+				<section
+					aria-label="Notifications"
+					className="pointer-events-none fixed left-1/2 top-4 z-[60] flex w-[calc(100vw-2rem)] -translate-x-1/2 flex-col gap-2 sm:bottom-4 sm:left-auto sm:right-4 sm:top-auto sm:translate-x-0 sm:w-auto"
+				>
+					{toasts.map((t) => (
+						<div key={t.id} className="pointer-events-auto">
+							<Toast toast={t} onDismiss={dismiss} onShowDetails={openDetails} />
+						</div>
+					))}
+					{toasts.length >= 2 && (
+						<div className="pointer-events-auto flex justify-end">
+							<button
+								type="button"
+								onClick={dismissAll}
+								className="rounded px-2 py-1 text-xs text-gray-500 underline hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+							>
+								Clear all
+							</button>
+						</div>
+					)}
+				</section>
+			)}
+			<SlideOver open={detailsOpen} onClose={closeDetails} title="Details">
+				{typeof detailsContent === "string" ? (
+					<pre className="whitespace-pre-wrap break-all text-sm text-gray-800 dark:text-gray-200">
+						{detailsContent}
+					</pre>
+				) : (
+					detailsContent
+				)}
+			</SlideOver>
+		</>
+	);
+}

--- a/src/components/__tests__/Toast.test.tsx
+++ b/src/components/__tests__/Toast.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ToastItem } from "../../lib/toast";
+import { Toast } from "../Toast";
+
+function makeToast(overrides: Partial<ToastItem> = {}): ToastItem {
+	return {
+		id: "test-id",
+		severity: "info",
+		message: "Test message",
+		duration: 0,
+		count: 1,
+		createdAt: Date.now(),
+		...overrides,
+	};
+}
+
+describe("Toast", () => {
+	it("renders message", () => {
+		render(
+			<Toast
+				toast={makeToast({ message: "Hello world" })}
+				onDismiss={() => {}}
+				onShowDetails={() => {}}
+			/>,
+		);
+		expect(screen.getByText("Hello world")).toBeInTheDocument();
+	});
+
+	it("renders role=alert for error", () => {
+		render(
+			<Toast
+				toast={makeToast({ severity: "error" })}
+				onDismiss={() => {}}
+				onShowDetails={() => {}}
+			/>,
+		);
+		expect(screen.getByRole("alert")).toBeInTheDocument();
+	});
+
+	it("renders role=alert for warning", () => {
+		render(
+			<Toast
+				toast={makeToast({ severity: "warning" })}
+				onDismiss={() => {}}
+				onShowDetails={() => {}}
+			/>,
+		);
+		expect(screen.getByRole("alert")).toBeInTheDocument();
+	});
+
+	it("renders role=status for success", () => {
+		render(
+			<Toast
+				toast={makeToast({ severity: "success" })}
+				onDismiss={() => {}}
+				onShowDetails={() => {}}
+			/>,
+		);
+		expect(screen.getByRole("status")).toBeInTheDocument();
+	});
+
+	it("renders role=status for info", () => {
+		render(
+			<Toast
+				toast={makeToast({ severity: "info" })}
+				onDismiss={() => {}}
+				onShowDetails={() => {}}
+			/>,
+		);
+		expect(screen.getByRole("status")).toBeInTheDocument();
+	});
+
+	it("shows count badge when count > 1", () => {
+		render(<Toast toast={makeToast({ count: 3 })} onDismiss={() => {}} onShowDetails={() => {}} />);
+		expect(screen.getByText("×3")).toBeInTheDocument();
+	});
+
+	it("hides count badge when count = 1", () => {
+		render(<Toast toast={makeToast({ count: 1 })} onDismiss={() => {}} onShowDetails={() => {}} />);
+		expect(screen.queryByText(/×/)).not.toBeInTheDocument();
+	});
+
+	it("shows Details... link when details set", () => {
+		render(
+			<Toast
+				toast={makeToast({ details: "full error body" })}
+				onDismiss={() => {}}
+				onShowDetails={() => {}}
+			/>,
+		);
+		expect(screen.getByText("Details...")).toBeInTheDocument();
+	});
+
+	it("hides Details... link when no details", () => {
+		render(<Toast toast={makeToast()} onDismiss={() => {}} onShowDetails={() => {}} />);
+		expect(screen.queryByText("Details...")).not.toBeInTheDocument();
+	});
+
+	it("calls onDismiss when close button clicked", () => {
+		const onDismiss = vi.fn();
+		render(
+			<Toast toast={makeToast({ id: "abc" })} onDismiss={onDismiss} onShowDetails={() => {}} />,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Dismiss notification" }));
+		expect(onDismiss).toHaveBeenCalledWith("abc");
+	});
+
+	it("calls onShowDetails when Details... clicked", () => {
+		const onShowDetails = vi.fn();
+		render(
+			<Toast
+				toast={makeToast({ details: "some details" })}
+				onDismiss={() => {}}
+				onShowDetails={onShowDetails}
+			/>,
+		);
+		fireEvent.click(screen.getByText("Details..."));
+		expect(onShowDetails).toHaveBeenCalledWith("some details");
+	});
+});

--- a/src/lib/__tests__/toast.test.tsx
+++ b/src/lib/__tests__/toast.test.tsx
@@ -1,0 +1,142 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ToastProvider, useToast } from "../toast";
+
+function wrapper({ children }: { children: React.ReactNode }) {
+	return <ToastProvider>{children}</ToastProvider>;
+}
+
+describe("useToast", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("toast.error adds a toast and returns id", () => {
+		const { result } = renderHook(() => useToast(), { wrapper });
+		let id = "";
+		act(() => {
+			id = result.current.toast.error("Something broke");
+		});
+		// useToast doesn't expose toasts directly — use context
+		// Just verify id is a non-empty string
+		expect(id).toBeTruthy();
+		expect(typeof id).toBe("string");
+	});
+});
+
+// Test ToastContext state more directly
+import { useContext } from "react";
+import { ToastContext } from "../toast";
+
+function useToastCtx() {
+	return useContext(ToastContext);
+}
+
+describe("ToastContext provider", () => {
+	beforeEach(() => vi.useFakeTimers());
+	afterEach(() => vi.useRealTimers());
+
+	it("adds toast to list", () => {
+		const { result } = renderHook(() => useToastCtx(), { wrapper });
+		act(() => {
+			result.current.add("error", "Oops");
+		});
+		expect(result.current.toasts).toHaveLength(1);
+		expect(result.current.toasts[0].severity).toBe("error");
+		expect(result.current.toasts[0].message).toBe("Oops");
+		expect(result.current.toasts[0].count).toBe(1);
+	});
+
+	it("dedup within 2s bumps count instead of adding", () => {
+		const { result } = renderHook(() => useToastCtx(), { wrapper });
+		act(() => {
+			result.current.add("error", "Oops");
+			result.current.add("error", "Oops");
+		});
+		expect(result.current.toasts).toHaveLength(1);
+		expect(result.current.toasts[0].count).toBe(2);
+	});
+
+	it("dedup after 2s window adds new toast", () => {
+		const { result } = renderHook(() => useToastCtx(), { wrapper });
+		act(() => {
+			result.current.add("error", "Oops");
+		});
+		act(() => {
+			vi.advanceTimersByTime(2001);
+			result.current.add("error", "Oops");
+		});
+		expect(result.current.toasts).toHaveLength(2);
+	});
+
+	it("queues 4th toast; pops when one dismissed", () => {
+		const { result } = renderHook(() => useToastCtx(), { wrapper });
+		act(() => {
+			result.current.add("info", "A");
+			result.current.add("info", "B");
+			result.current.add("info", "C");
+			result.current.add("info", "D");
+		});
+		expect(result.current.toasts).toHaveLength(3);
+		act(() => {
+			result.current.dismiss(result.current.toasts[0].id);
+		});
+		expect(result.current.toasts).toHaveLength(3);
+		expect(result.current.toasts[2].message).toBe("D");
+	});
+
+	it("dismissAll clears visible and queue", () => {
+		const { result } = renderHook(() => useToastCtx(), { wrapper });
+		act(() => {
+			result.current.add("info", "A");
+			result.current.add("info", "B");
+			result.current.add("info", "C");
+			result.current.add("info", "D");
+		});
+		act(() => {
+			result.current.dismissAll();
+		});
+		expect(result.current.toasts).toHaveLength(0);
+		// Queue cleared — add one more to verify no D pops
+		act(() => {
+			result.current.add("info", "E");
+		});
+		expect(result.current.toasts).toHaveLength(1);
+		expect(result.current.toasts[0].message).toBe("E");
+	});
+
+	it("update mutates toast in place", () => {
+		const { result } = renderHook(() => useToastCtx(), { wrapper });
+		let id = "";
+		act(() => {
+			id = result.current.add("info", "Loading...", { duration: 0 });
+		});
+		act(() => {
+			result.current.update(id, { severity: "success", message: "Done!" });
+		});
+		const t = result.current.toasts.find((x) => x.id === id);
+		expect(t?.severity).toBe("success");
+		expect(t?.message).toBe("Done!");
+	});
+
+	it("openDetails sets content and detailsOpen", () => {
+		const { result } = renderHook(() => useToastCtx(), { wrapper });
+		act(() => {
+			result.current.openDetails("error body");
+		});
+		expect(result.current.detailsOpen).toBe(true);
+		expect(result.current.detailsContent).toBe("error body");
+	});
+
+	it("closeDetails sets detailsOpen false", () => {
+		const { result } = renderHook(() => useToastCtx(), { wrapper });
+		act(() => {
+			result.current.openDetails("x");
+			result.current.closeDetails();
+		});
+		expect(result.current.detailsOpen).toBe(false);
+	});
+});

--- a/src/lib/toast.tsx
+++ b/src/lib/toast.tsx
@@ -1,0 +1,166 @@
+import { createContext, type ReactNode, useContext, useRef, useState } from "react";
+import { Toaster } from "../components/Toaster";
+
+export type Severity = "error" | "warning" | "success" | "info";
+
+export interface ToastItem {
+	id: string;
+	severity: Severity;
+	message: string;
+	details?: ReactNode | string;
+	duration: number;
+	count: number;
+	createdAt: number;
+}
+
+export interface ToastOptions {
+	details?: ReactNode | string;
+	duration?: number;
+	id?: string;
+}
+
+export interface UpdateOptions {
+	severity?: Severity;
+	message?: string;
+	details?: ReactNode | string;
+	duration?: number;
+}
+
+interface ToastContextValue {
+	toasts: ToastItem[];
+	add: (severity: Severity, message: string, opts?: ToastOptions) => string;
+	update: (id: string, opts: UpdateOptions) => void;
+	dismiss: (id: string) => void;
+	dismissAll: () => void;
+	detailsContent: ReactNode | string | null;
+	detailsOpen: boolean;
+	openDetails: (content: ReactNode | string) => void;
+	closeDetails: () => void;
+}
+
+const MAX_VISIBLE = 3;
+const DEDUP_WINDOW_MS = 2000;
+
+const DEFAULT_DURATIONS: Record<Severity, number> = {
+	error: 0,
+	warning: 6000,
+	success: 3000,
+	info: 4000,
+};
+
+const defaultContext: ToastContextValue = {
+	toasts: [],
+	add: () => "",
+	update: () => {},
+	dismiss: () => {},
+	dismissAll: () => {},
+	detailsContent: null,
+	detailsOpen: false,
+	openDetails: () => {},
+	closeDetails: () => {},
+};
+
+export const ToastContext = createContext<ToastContextValue>(defaultContext);
+
+export function useToast() {
+	const ctx = useContext(ToastContext);
+	const { add, update, dismiss, dismissAll } = ctx;
+
+	const toast = {
+		error: (message: string, opts?: ToastOptions) => add("error", message, opts),
+		warning: (message: string, opts?: ToastOptions) => add("warning", message, opts),
+		success: (message: string, opts?: ToastOptions) => add("success", message, opts),
+		info: (message: string, opts?: ToastOptions) => add("info", message, opts),
+		update,
+	};
+
+	return { toast, dismiss, dismissAll };
+}
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+	const [toasts, setToasts] = useState<ToastItem[]>([]);
+	const [detailsOpen, setDetailsOpen] = useState(false);
+	const [detailsContent, setDetailsContent] = useState<ReactNode | string | null>(null);
+	const queueRef = useRef<ToastItem[]>([]);
+
+	function add(severity: Severity, message: string, opts?: ToastOptions): string {
+		const id = opts?.id ?? crypto.randomUUID();
+		const now = Date.now();
+		const duration = opts?.duration !== undefined ? opts.duration : DEFAULT_DURATIONS[severity];
+
+		setToasts((prev) => {
+			const existing = prev.find(
+				(t) =>
+					t.severity === severity && t.message === message && now - t.createdAt < DEDUP_WINDOW_MS,
+			);
+			if (existing) {
+				return prev.map((t) => (t.id === existing.id ? { ...t, count: t.count + 1 } : t));
+			}
+			const newToast: ToastItem = {
+				id,
+				severity,
+				message,
+				details: opts?.details,
+				duration,
+				count: 1,
+				createdAt: now,
+			};
+			if (prev.length >= MAX_VISIBLE) {
+				queueRef.current = [...queueRef.current, newToast];
+				return prev;
+			}
+			return [...prev, newToast];
+		});
+
+		return id;
+	}
+
+	function update(id: string, opts: UpdateOptions) {
+		setToasts((prev) => prev.map((t) => (t.id === id ? { ...t, ...opts } : t)));
+	}
+
+	function dismiss(id: string) {
+		setToasts((prev) => {
+			const next = prev.filter((t) => t.id !== id);
+			if (queueRef.current.length > 0 && next.length < MAX_VISIBLE) {
+				const [queued, ...remaining] = queueRef.current;
+				queueRef.current = remaining;
+				return [...next, queued];
+			}
+			return next;
+		});
+	}
+
+	function dismissAll() {
+		queueRef.current = [];
+		setToasts([]);
+	}
+
+	function openDetails(content: ReactNode | string) {
+		setDetailsContent(content);
+		setDetailsOpen(true);
+	}
+
+	function closeDetails() {
+		setDetailsOpen(false);
+	}
+
+	return (
+		<ToastContext
+			value={{
+				toasts,
+				add,
+				update,
+				dismiss,
+				dismissAll,
+				detailsContent,
+				detailsOpen,
+				openDetails,
+				closeDetails,
+			}}
+		>
+			{children}
+			<Toaster />
+		</ToastContext>
+	);
+}

--- a/src/pages/schemas/SchemaDetail.tsx
+++ b/src/pages/schemas/SchemaDetail.tsx
@@ -15,6 +15,7 @@ import { useApiClient, useSchema } from "../../lib/hooks";
 import { CHEVRON_DOWN, CHEVRON_RIGHT } from "../../lib/icons";
 import { label } from "../../lib/labels";
 import { canManageSchemas } from "../../lib/permissions";
+import { useToast } from "../../lib/toast";
 
 type SchemaField = components["schemas"]["v1SchemaField"];
 type FieldConstraints = components["schemas"]["v1FieldConstraints"];
@@ -27,6 +28,7 @@ export function SchemaDetail() {
 	const { data, isLoading, error } = useSchema(id ?? "");
 	const client = useApiClient();
 	const queryClient = useQueryClient();
+	const { toast } = useToast();
 
 	const schema = data?.schema;
 	const schemaId = id ?? "";
@@ -41,9 +43,11 @@ export function SchemaDetail() {
 			return result;
 		},
 		onSuccess: () => {
+			toast.success("Schema published");
 			queryClient.invalidateQueries({ queryKey: ["schemas", id] });
 			queryClient.invalidateQueries({ queryKey: ["schemas"] });
 		},
+		onError: (err: Error) => toast.error(`Publish failed: ${err.message}`),
 	});
 
 	const handleExport = async () => {
@@ -51,7 +55,7 @@ export function SchemaDetail() {
 			params: { path: { id: schemaId } },
 		});
 		if (err) {
-			alert(`Export failed: ${formatError(err)}`);
+			toast.error(`Export failed: ${formatError(err)}`);
 			return;
 		}
 		const yaml = result?.yamlContent ?? "";
@@ -105,12 +109,6 @@ export function SchemaDetail() {
 							</button>
 						</div>
 					</div>
-
-					{publishMutation.isError && (
-						<p className="mb-4 text-red-600 dark:text-red-400">
-							Publish failed: {publishMutation.error.message}
-						</p>
-					)}
 
 					<div className="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-3">
 						<InfoCard label="Version" value={`v${schema.version}`} />

--- a/src/pages/tenants/TenantDetail.tsx
+++ b/src/pages/tenants/TenantDetail.tsx
@@ -26,6 +26,7 @@ import {
 } from "../../lib/hooks";
 import { label } from "../../lib/labels";
 import { canEditConfig, canManageLocks, canManageTenants } from "../../lib/permissions";
+import { useToast } from "../../lib/toast";
 
 type SchemaField = components["schemas"]["v1SchemaField"];
 type TypedValue = components["schemas"]["v1TypedValue"];
@@ -74,6 +75,7 @@ export function TenantDetail() {
 	const client = useApiClient();
 	const queryClient = useQueryClient();
 
+	const { toast } = useToast();
 	const { data: tenantData, isLoading: tenantLoading, error: tenantError } = useTenant(tid);
 	const tenant = tenantData?.tenant;
 
@@ -94,7 +96,6 @@ export function TenantDetail() {
 	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 	const [pendingChanges, setPendingChanges] = useState<Map<string, string>>(new Map());
 	const [description, setDescription] = useState("");
-	const [applyError, setApplyError] = useState<string | null>(null);
 
 	const fields = schema?.fields ?? [];
 	const configValues = config?.values ?? [];
@@ -172,7 +173,6 @@ export function TenantDetail() {
 				else next.set(path, value);
 				return next;
 			});
-			setApplyError(null);
 		},
 		[serverValueMap],
 	);
@@ -188,7 +188,6 @@ export function TenantDetail() {
 	const handleResetAll = useCallback(() => {
 		setPendingChanges(new Map());
 		setDescription("");
-		setApplyError(null);
 	}, []);
 
 	const handleCancelEdit = useCallback(() => {
@@ -213,14 +212,14 @@ export function TenantDetail() {
 			if (err) throw new Error(formatError(err));
 		},
 		onSuccess: () => {
+			toast.success("Config saved");
 			setPendingChanges(new Map());
 			setDescription("");
-			setApplyError(null);
 			setEditing(false);
 			queryClient.invalidateQueries({ queryKey: ["config", tid] });
 			queryClient.invalidateQueries({ queryKey: ["versions", tid] });
 		},
-		onError: (err: Error) => setApplyError(err.message),
+		onError: (err: Error) => toast.error(err.message),
 	});
 
 	const deleteMutation = useMutation({
@@ -231,9 +230,11 @@ export function TenantDetail() {
 			if (err) throw new Error(formatError(err));
 		},
 		onSuccess: () => {
+			toast.success("Tenant deleted");
 			queryClient.invalidateQueries({ queryKey: ["tenants"] });
 			navigate("/tenants");
 		},
+		onError: (err: Error) => toast.error(`Delete failed: ${err.message}`),
 	});
 
 	const lockMutation = useMutation({
@@ -244,7 +245,11 @@ export function TenantDetail() {
 			});
 			if (err) throw new Error(formatError(err));
 		},
-		onSuccess: () => queryClient.invalidateQueries({ queryKey: ["locks", tid] }),
+		onSuccess: () => {
+			toast.success("Field locked");
+			queryClient.invalidateQueries({ queryKey: ["locks", tid] });
+		},
+		onError: (err: Error) => toast.error(`Lock failed: ${err.message}`),
 	});
 
 	const unlockMutation = useMutation({
@@ -254,7 +259,11 @@ export function TenantDetail() {
 			});
 			if (err) throw new Error(formatError(err));
 		},
-		onSuccess: () => queryClient.invalidateQueries({ queryKey: ["locks", tid] }),
+		onSuccess: () => {
+			toast.success("Field unlocked");
+			queryClient.invalidateQueries({ queryKey: ["locks", tid] });
+		},
+		onError: (err: Error) => toast.error(`Unlock failed: ${err.message}`),
 	});
 
 	const isLoading = tenantLoading || schemaLoading || configLoading;
@@ -383,12 +392,6 @@ export function TenantDetail() {
 						</div>
 					</div>
 
-					{deleteMutation.isError && (
-						<p className="mb-4 text-red-600 dark:text-red-400">
-							Delete failed: {deleteMutation.error.message}
-						</p>
-					)}
-
 					{groups.length === 0 && (
 						<p className="text-gray-500 dark:text-gray-400">{label("schema.noFields")}</p>
 					)}
@@ -441,7 +444,6 @@ export function TenantDetail() {
 							onApply={() => applyMutation.mutate()}
 							onReset={handleResetAll}
 							isApplying={applyMutation.isPending}
-							applyError={applyError}
 						/>
 					)}
 				</>


### PR DESCRIPTION
## Summary

- The UI had no consistent way to surface errors or success states — failures appeared as browser `alert()` dialogs, inline red text, or were silently swallowed (lock/unlock had no error surface at all). This PR replaces all of that with a single global system.
- Implements `ToastProvider` / `useToast()` with dedup, a 3-toast visible queue, severity-based auto-dismiss timers, hover-pause, and a Details slide-over for long server error bodies.
- Migrates all ad-hoc error surfaces in `SchemaDetail`, `TenantDetail`, `ConfigHistory`, and `PendingChangesBar`, and adds success toasts for apply, delete, publish, import, lock/unlock, and rollback — all of which were previously silent.

## Test plan

- [x] Lint (`biome check`) — clean
- [x] Typecheck (`tsc --noEmit`) — clean
- [x] Unit tests: 23 passing (11 Toast component tests + 9 provider/hook tests + 3 existing)
- [x] Production build — 107 modules, no errors
- [ ] Manual smoke: trigger apply failure → toast.error with Details link → click → SlideOver opens
- [ ] Manual smoke: successful apply → `toast.success("Config saved")`
- [ ] Manual smoke: 4 rapid errors → 3 visible, 1 queued; dismiss one → queued pops in
- [ ] Manual smoke: 2 identical errors within 2 s → ×2 badge
- [ ] Manual smoke: mobile viewport (<640 px) → toast appears top-center
- [ ] Manual smoke: dark mode → correct colors

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)