### PR TITLE
feat(ui): add React error boundary for graceful render error handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 import { EmbedLayout } from "./components/EmbedLayout";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import { Layout } from "./components/Layout";
 import type { AuthState } from "./lib/auth";
 import { AuthContext, loadAuth, saveAuth } from "./lib/auth";
@@ -48,30 +49,32 @@ export function App() {
 		<AuthContext value={{ auth, setAuth }}>
 			<QueryClientProvider client={queryClient}>
 				<ToastProvider>
-					<Routes>
-						{/* Standard layout with sidebar + header */}
-						<Route element={<Layout />}>
-							<Route index element={<HomeOrRedirect />} />
-							<Route path="schemas" element={<SchemaList />} />
-							<Route path="schemas/import" element={<SchemaImport />} />
-							<Route path="schemas/:id" element={<SchemaDetail />} />
-							<Route path="tenants" element={<TenantList />} />
-							<Route path="tenants/create" element={<TenantCreate />} />
-							<Route path="tenants/:id" element={<TenantDetail />} />
-							<Route path="tenants/:id/history" element={<TenantHistory />} />
-							<Route path="tenants/:id/audit" element={<TenantAudit />} />
-							<Route path="tenants/:id/usage" element={<TenantUsage />} />
-							<Route path="*" element={<NotFound />} />
-						</Route>
+					<ErrorBoundary>
+						<Routes>
+							{/* Standard layout with sidebar + header */}
+							<Route element={<Layout />}>
+								<Route index element={<HomeOrRedirect />} />
+								<Route path="schemas" element={<SchemaList />} />
+								<Route path="schemas/import" element={<SchemaImport />} />
+								<Route path="schemas/:id" element={<SchemaDetail />} />
+								<Route path="tenants" element={<TenantList />} />
+								<Route path="tenants/create" element={<TenantCreate />} />
+								<Route path="tenants/:id" element={<TenantDetail />} />
+								<Route path="tenants/:id/history" element={<TenantHistory />} />
+								<Route path="tenants/:id/audit" element={<TenantAudit />} />
+								<Route path="tenants/:id/usage" element={<TenantUsage />} />
+								<Route path="*" element={<NotFound />} />
+							</Route>
 
-						{/* Embed layout — no sidebar, no header, for iframe use */}
-						<Route path="embed" element={<EmbedLayout />}>
-							<Route path="tenants/:id" element={<TenantDetail />} />
-							<Route path="tenants/:id/audit" element={<TenantAudit />} />
-							<Route path="tenants/:id/usage" element={<TenantUsage />} />
-							<Route path="schemas/:id" element={<SchemaDetail />} />
-						</Route>
-					</Routes>
+							{/* Embed layout — no sidebar, no header, for iframe use */}
+							<Route path="embed" element={<EmbedLayout />}>
+								<Route path="tenants/:id" element={<TenantDetail />} />
+								<Route path="tenants/:id/audit" element={<TenantAudit />} />
+								<Route path="tenants/:id/usage" element={<TenantUsage />} />
+								<Route path="schemas/:id" element={<SchemaDetail />} />
+							</Route>
+						</Routes>
+					</ErrorBoundary>
 				</ToastProvider>
 			</QueryClientProvider>
 		</AuthContext>

--- a/src/components/EmbedLayout.tsx
+++ b/src/components/EmbedLayout.tsx
@@ -1,10 +1,13 @@
 import { Outlet } from "react-router-dom";
+import { ErrorBoundary } from "./ErrorBoundary";
 
 /** Minimal layout for iframe embedding — no sidebar, no header. */
 export function EmbedLayout() {
 	return (
 		<main className="h-screen overflow-auto p-4">
-			<Outlet />
+			<ErrorBoundary>
+				<Outlet />
+			</ErrorBoundary>
 		</main>
 	);
 }

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,68 @@
+import type { ErrorInfo, ReactNode } from "react";
+import { Component } from "react";
+
+interface Props {
+	children: ReactNode;
+	/** Custom fallback — defaults to the built-in error card. */
+	fallback?: (error: Error, reset: () => void) => ReactNode;
+}
+
+interface State {
+	error: Error | null;
+}
+
+/**
+ * Catches render errors in its subtree. In development the component stack
+ * is logged to the console via componentDidCatch.
+ */
+export class ErrorBoundary extends Component<Props, State> {
+	state: State = { error: null };
+
+	static getDerivedStateFromError(error: Error): State {
+		return { error };
+	}
+
+	componentDidCatch(error: Error, info: ErrorInfo) {
+		if (import.meta.env.DEV) {
+			console.error("[ErrorBoundary]", error, info.componentStack);
+		}
+	}
+
+	reset = () => this.setState({ error: null });
+
+	render() {
+		const { error } = this.state;
+		if (error) {
+			if (this.props.fallback) {
+				return this.props.fallback(error, this.reset);
+			}
+			return <ErrorFallback error={error} onRetry={this.reset} />;
+		}
+		return this.props.children;
+	}
+}
+
+function ErrorFallback({ error, onRetry }: { error: Error; onRetry: () => void }) {
+	return (
+		<div className="flex flex-col items-center justify-center gap-4 p-8 text-center">
+			<p className="text-lg font-semibold text-red-600 dark:text-red-400">Something went wrong</p>
+			<p className="max-w-sm text-sm text-gray-600 dark:text-gray-400">{error.message}</p>
+			<div className="flex gap-3">
+				<button
+					type="button"
+					onClick={onRetry}
+					className="rounded bg-gray-200 px-3 py-1.5 text-sm font-medium hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
+				>
+					Retry
+				</button>
+				<button
+					type="button"
+					onClick={() => window.location.reload()}
+					className="rounded bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700"
+				>
+					Reload page
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import { label } from "../lib/labels";
 import { canManageSchemas, canManageTenants } from "../lib/permissions";
 import { AuthBar } from "./AuthBar";
 import { DarkModeToggle } from "./DarkModeToggle";
+import { ErrorBoundary } from "./ErrorBoundary";
 
 // --- Sidebar icons (simple inline SVGs, 16x16) ---
 
@@ -210,7 +211,9 @@ export function Layout() {
 
 				{/* Content */}
 				<main className="flex-1 overflow-auto p-6">
-					<Outlet />
+					<ErrorBoundary>
+						<Outlet />
+					</ErrorBoundary>
 				</main>
 			</div>
 		</div>


### PR DESCRIPTION
## Summary

- Unhandled render errors previously crashed the entire app, leaving users with a blank screen and no recovery path.
- Adds a top-level `ErrorBoundary` in `App` wrapping the full route tree, plus a per-page `ErrorBoundary` around the `<Outlet>` in `Layout` and `EmbedLayout` so a single page crash does not take down the sidebar or header.
- Fallback UI shows the error message with Retry and Reload buttons; component stack is logged to the console in development only. No new external dependencies.

## Test plan

- [ ] Verify the app loads normally with no regressions
- [ ] Throw a render error in a page component and confirm the per-page fallback appears (sidebar and header remain intact)
- [ ] Confirm the Retry button resets the boundary and re-renders the page
- [ ] Confirm the Reload button triggers a full page reload
- [ ] Throw a render error above the Layout level and confirm the top-level fallback appears
- [ ] Check browser console in dev mode — component stack should be logged; verify nothing is logged in production build

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)