### PR TITLE
feat(ui): replace text loading states with skeleton components

### DIFF
--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,0 +1,44 @@
+/** Animated shimmer primitives for skeleton loading states. */
+
+/** A single line placeholder. Width defaults to full. */
+export function SkeletonLine({ className = "w-full" }: { className?: string }) {
+	return <div className={`h-4 animate-pulse rounded bg-gray-200 dark:bg-gray-700 ${className}`} />;
+}
+
+/** A rectangular block placeholder (e.g. for cards or images). */
+export function SkeletonBlock({ className = "" }: { className?: string }) {
+	return <div className={`animate-pulse rounded bg-gray-200 dark:bg-gray-700 ${className}`} />;
+}
+
+/** N rows of skeleton lines that approximate a table or list. */
+export function SkeletonTable({ rows = 5 }: { rows?: number }) {
+	return (
+		<div className="space-y-3">
+			{Array.from({ length: rows }, (_, i) => (
+				// biome-ignore lint/suspicious/noArrayIndexKey: skeleton rows have no identity
+				<div key={i} className="flex gap-4">
+					<SkeletonLine className="w-1/4" />
+					<SkeletonLine className="w-1/3" />
+					<SkeletonLine className="w-1/5" />
+					<SkeletonLine className="w-1/6" />
+				</div>
+			))}
+		</div>
+	);
+}
+
+/** Skeleton approximating a detail/form card (heading + several field rows). */
+export function SkeletonDetail() {
+	return (
+		<div className="space-y-6">
+			<SkeletonLine className="w-1/3" />
+			<div className="space-y-4">
+				<SkeletonLine className="w-full" />
+				<SkeletonLine className="w-5/6" />
+				<SkeletonLine className="w-4/6" />
+				<SkeletonLine className="w-full" />
+				<SkeletonLine className="w-3/6" />
+			</div>
+		</div>
+	);
+}

--- a/src/pages/schemas/SchemaDetail.tsx
+++ b/src/pages/schemas/SchemaDetail.tsx
@@ -8,6 +8,7 @@ import {
 	SensitiveBadge,
 	WriteOnceBadge,
 } from "../../components/FieldBadges";
+import { SkeletonDetail } from "../../components/Skeleton";
 import { useAuth } from "../../lib/auth";
 import { fieldTypeColor, fieldTypeIcon, fieldTypeLabel } from "../../lib/field-types";
 import { groupFields } from "../../lib/fields";
@@ -76,7 +77,7 @@ export function SchemaDetail() {
 				</Link>
 			</div>
 
-			{isLoading && <p className="text-gray-500 dark:text-gray-400">Loading schema...</p>}
+			{isLoading && <SkeletonDetail />}
 
 			{error && (
 				<p className="text-red-600 dark:text-red-400">Error loading schema: {error.message}</p>

--- a/src/pages/schemas/SchemaList.tsx
+++ b/src/pages/schemas/SchemaList.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
+import { SkeletonTable } from "../../components/Skeleton";
 import { useAuth } from "../../lib/auth";
 import { useSchemas } from "../../lib/hooks";
 import { label } from "../../lib/labels";
@@ -40,7 +41,7 @@ export function SchemaList() {
 				/>
 			</div>
 
-			{isLoading && <p className="text-gray-500 dark:text-gray-400">Loading schemas...</p>}
+			{isLoading && <SkeletonTable rows={4} />}
 
 			{error && (
 				<p className="text-red-600 dark:text-red-400">Error loading schemas: {error.message}</p>

--- a/src/pages/tenants/TenantAudit.tsx
+++ b/src/pages/tenants/TenantAudit.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { AuditRow } from "../../components/FieldChanges";
+import { SkeletonTable } from "../../components/Skeleton";
 import { config } from "../../lib/config";
 import { useAuditLog, useTenant } from "../../lib/hooks";
 import { label } from "../../lib/labels";
@@ -58,9 +59,7 @@ export function TenantAudit() {
 				/>
 			</div>
 
-			{isLoading && (
-				<p className="text-sm text-gray-500 dark:text-gray-400">{label("common.loading")}</p>
-			)}
+			{isLoading && <SkeletonTable rows={5} />}
 
 			{!isLoading && entries.length === 0 && (
 				<p className="text-sm text-gray-500 dark:text-gray-400">No audit entries found.</p>

--- a/src/pages/tenants/TenantDetail.tsx
+++ b/src/pages/tenants/TenantDetail.tsx
@@ -10,6 +10,7 @@ import {
 	WriteOnceBadge,
 } from "../../components/FieldBadges";
 import { PendingChangesBar } from "../../components/PendingChangesBar";
+import { SkeletonDetail } from "../../components/Skeleton";
 import { SlideOver } from "../../components/SlideOver";
 import { TypedInput } from "../../components/TypedInput";
 import { useAuth } from "../../lib/auth";
@@ -281,7 +282,7 @@ export function TenantDetail() {
 				</div>
 			)}
 
-			{isLoading && <p className="text-gray-500 dark:text-gray-400">{label("common.loading")}</p>}
+			{isLoading && <SkeletonDetail />}
 			{tenantError && (
 				<p className="text-red-600 dark:text-red-400">Error: {tenantError.message}</p>
 			)}

--- a/src/pages/tenants/TenantList.tsx
+++ b/src/pages/tenants/TenantList.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
+import { SkeletonTable } from "../../components/Skeleton";
 import { useAuth } from "../../lib/auth";
 import { useSchemas, useTenants } from "../../lib/hooks";
 import { label } from "../../lib/labels";
@@ -49,7 +50,7 @@ export function TenantList() {
 				/>
 			</div>
 
-			{isLoading && <p className="text-gray-500 dark:text-gray-400">Loading tenants...</p>}
+			{isLoading && <SkeletonTable rows={5} />}
 
 			{error && (
 				<p className="text-red-600 dark:text-red-400">Error loading tenants: {error.message}</p>

--- a/src/pages/tenants/TenantUsage.tsx
+++ b/src/pages/tenants/TenantUsage.tsx
@@ -1,4 +1,5 @@
 import { Link, useParams } from "react-router-dom";
+import { SkeletonTable } from "../../components/Skeleton";
 import { config } from "../../lib/config";
 import { useTenant, useTenantUsage } from "../../lib/hooks";
 import { label } from "../../lib/labels";
@@ -36,9 +37,7 @@ export function TenantUsage() {
 
 			<h2 className="mb-4 text-xl font-semibold">Usage Stats — {tenant?.name}</h2>
 
-			{isLoading && (
-				<p className="text-sm text-gray-500 dark:text-gray-400">{label("common.loading")}</p>
-			)}
+			{isLoading && <SkeletonTable rows={4} />}
 
 			{!isLoading && stats.length === 0 && (
 				<p className="text-sm text-gray-500 dark:text-gray-400">No usage data recorded yet.</p>


### PR DESCRIPTION
## Summary

- Plain "Loading..." text gave no visual structure while data was fetching, making the app feel unpolished and slow.
- Introduces reusable skeleton primitives (`SkeletonLine`, `SkeletonBlock`, `SkeletonTable`, `SkeletonDetail`) in `src/components/Skeleton.tsx` using Tailwind `animate-pulse`.
- Replaces loading states in all six affected pages with skeleton shapes that approximate the content layout (table rows for list pages, heading + field rows for detail pages).

## Test plan

- [ ] Load SchemaList with a slow network — verify animated skeleton rows appear before data
- [ ] Load SchemaDetail — verify skeleton detail card appears during fetch
- [ ] Load TenantList — verify skeleton table rows appear
- [ ] Load TenantDetail — verify skeleton detail appears while all three queries resolve
- [ ] Load TenantAudit and TenantUsage — verify skeleton table rows appear
- [ ] Confirm no new npm dependencies were added

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)