### PR TITLE
ci: add Codecov coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,15 @@ jobs:
       - *checkout
       - *setup-node-22
       - *install
-      - name: Run tests
-        run: npm test
+      - name: Run tests with coverage
+        run: npm run test:coverage
+
+      - name: Upload coverage to Codecov
+        # codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
+        with:
+          files: coverage/coverage-final.json
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   build:
     name: Build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing to decree-ui
+
+Thank you for your interest in contributing! This guide covers everything you need to get started.
+
+> **Alpha status** — APIs, UI, and behavior are subject to change without notice. Breaking changes may happen between any two commits during this phase.
+
+## Prerequisites
+
+- **Node.js v22** or later
+- A running [OpenDecree server](https://github.com/opendecree/decree) on `localhost:8080` for local development
+
+## Local setup
+
+```bash
+# 1. Install dependencies
+npm install
+
+# 2. Start the dev server (proxies /v1/* to localhost:8080)
+npm run dev
+```
+
+The app is available at `http://localhost:5173`.
+
+## Running checks
+
+```bash
+npm run lint        # Biome lint
+npm run typecheck   # TypeScript type check
+npm test            # Vitest unit tests
+npm run build       # Production build (also type-checks)
+npm run pre-commit  # All of the above + build, in sequence
+```
+
+Run `npm run pre-commit` before every commit. CI runs the same pipeline.
+
+## Code style
+
+[Biome](https://biomejs.dev/) enforces formatting and lint rules. Auto-fix with:
+
+```bash
+npx biome check --write src/
+```
+
+No Prettier, no ESLint — Biome only.
+
+## Submitting changes
+
+1. Fork the repo and create a feature branch off `main`.
+2. Make your changes.
+3. Run `npm run pre-commit` and fix any failures.
+4. Open a pull request against `main` with a clear description of what changed and why.
+
+Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/):
+`feat`, `fix`, `refactor`, `perf`, `docs`, `test`, `chore`, `build`, `ci`.
+
+## Reporting issues
+
+Use [GitHub Issues](https://github.com/opendecree/decree-ui/issues). For security issues, see [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/opendecree/decree-ui/actions/workflows/ci.yml/badge.svg)](https://github.com/opendecree/decree-ui/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/opendecree/decree-ui)](LICENSE)
 [![Project Status: WIP](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
+[![codecov](https://codecov.io/gh/opendecree/decree-ui/graph/badge.svg)](https://codecov.io/gh/opendecree/decree-ui)
 
 Web-based admin interface for [OpenDecree](https://github.com/opendecree/decree) — schema-driven configuration management.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0%
+    patch:
+      default:
+        target: 80%


### PR DESCRIPTION
## Summary
- Codecov has no coverage data for the Admin GUI — this wires up uploads so the dashboard, PR delta comments, and badge all work
- Switches the test job from \`npm test\` to \`npm run test:coverage\` so vitest emits \`coverage/coverage-final.json\` via the v8 provider, then uploads it to Codecov
- Adds \`codecov.yml\` enforcing no project regression and ≥80% patch coverage

## Test plan
- [ ] Ensure \`CODECOV_TOKEN\` is set as org-level secret (handled in opendecree/decree#409)
- [ ] Verify coverage upload lands in Codecov dashboard after merge
- [ ] Confirm badge renders in README

Refs opendecree/decree#153

🤖 Generated with [Claude Code](https://claude.com/claude-code)