### PR TITLE
feat(deploy): support TENANT_ID_FILE and SCHEMA_ID_FILE env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,12 @@ ENV LAYOUT_MODE="full"
 # UI mode: full, single-tenant, single-schema. See docs/ui-modes.md.
 ENV TENANT_ID=""
 # Pre-selected tenant UUID or name slug. Required for single-tenant mode.
+ENV TENANT_ID_FILE=""
+# Path to a file containing the tenant ID (e.g. /data/tenant-id). Used when TENANT_ID is unset.
 ENV SCHEMA_ID=""
 # Pre-selected schema UUID or name slug. Required for single-schema mode.
+ENV SCHEMA_ID_FILE=""
+# Path to a file containing the schema ID. Used when SCHEMA_ID is unset.
 ENV DEFAULT_ROLE=""
 # Default auth role: superadmin, admin, user. Empty = superadmin.
 ENV DEFAULT_SUBJECT=""

--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -15,6 +15,16 @@ CONFIG_DIR="/usr/share/nginx/html"
 #
 # API_URL is used by nginx for reverse proxying /v1/ requests (Docker-internal hostname).
 
+# Resolve TENANT_ID: env var takes precedence; fall back to file.
+if [ -z "$TENANT_ID" ] && [ -n "$TENANT_ID_FILE" ] && [ -r "$TENANT_ID_FILE" ]; then
+  TENANT_ID=$(cat "$TENANT_ID_FILE")
+fi
+
+# Resolve SCHEMA_ID: env var takes precedence; fall back to file.
+if [ -z "$SCHEMA_ID" ] && [ -n "$SCHEMA_ID_FILE" ] && [ -r "$SCHEMA_ID_FILE" ]; then
+  SCHEMA_ID=$(cat "$SCHEMA_ID_FILE")
+fi
+
 cat > "$CONFIG_DIR/config.js" <<EOF
 window.__DECREE_UI_CONFIG__ = {
   apiUrl: "${BROWSER_API_URL}",

--- a/docs/ui-modes.md
+++ b/docs/ui-modes.md
@@ -208,6 +208,30 @@ The UI supports dark/light mode toggle. Future considerations:
 | `BROWSER_API_URL` | Browser API URL (empty = same origin) | `""` |
 | `LAYOUT_MODE` | UI mode | `full` |
 | `TENANT_ID` | Pre-selected tenant (UUID or slug) | `""` |
+| `TENANT_ID_FILE` | Path to file containing tenant ID (used when `TENANT_ID` is unset) | `""` |
 | `SCHEMA_ID` | Pre-selected schema (UUID or slug) | `""` |
+| `SCHEMA_ID_FILE` | Path to file containing schema ID (used when `SCHEMA_ID` is unset) | `""` |
 | `DEFAULT_ROLE` | Default auth role | `superadmin` |
 | `DEFAULT_SUBJECT` | Default auth subject | `admin` |
+
+## File-based ID injection
+
+`TENANT_ID_FILE` and `SCHEMA_ID_FILE` are a convenience for Docker Compose demos where IDs are written dynamically by a seed container. The env var (`TENANT_ID` / `SCHEMA_ID`) always wins; the file is only read when the env var is empty.
+
+```yaml
+admin:
+  environment:
+    LAYOUT_MODE: config-only
+    TENANT_ID_FILE: /data/tenant-id
+  volumes:
+    - seed-data:/data:ro
+```
+
+For real deployments, use the env var directly:
+
+```yaml
+admin:
+  environment:
+    LAYOUT_MODE: config-only
+    TENANT_ID: <uuid>
+```


### PR DESCRIPTION
## Summary

- Adds file-based fallback for `TENANT_ID` and `SCHEMA_ID` so Docker Compose demos can seed these values dynamically from a sibling container without baking them into the Compose file at deploy time.
- The env var always wins; the file is only read when the env var is empty.

## Test plan

- [ ] Set `TENANT_ID=abc` — verify config.js contains `tenantId: "abc"` (file ignored)
- [ ] Unset `TENANT_ID`, set `TENANT_ID_FILE` pointing to a file containing `xyz` — verify config.js contains `tenantId: "xyz"`
- [ ] Unset both — verify config.js contains `tenantId: ""`
- [ ] Same three cases for `SCHEMA_ID` / `SCHEMA_ID_FILE`
- [ ] Set `TENANT_ID_FILE` to a non-existent path — verify entrypoint does not error and `tenantId` is empty

Closes #10