### PR TITLE
docs: trim README badges to highest-signal set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # OpenDecree Admin GUI
 
 [![CI](https://github.com/opendecree/decree-ui/actions/workflows/ci.yml/badge.svg)](https://github.com/opendecree/decree-ui/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/opendecree/decree-ui/actions/workflows/codeql.yml/badge.svg)](https://github.com/opendecree/decree-ui/actions/workflows/codeql.yml)
 [![License](https://img.shields.io/github/license/opendecree/decree-ui)](LICENSE)
-[![Project Status: WIP](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![codecov](https://codecov.io/gh/opendecree/decree-ui/graph/badge.svg)](https://codecov.io/gh/opendecree/decree-ui)
 
 Web-based admin interface for [OpenDecree](https://github.com/opendecree/decree) — schema-driven configuration management.


### PR DESCRIPTION
## Summary
- Drop the repostatus "WIP" badge — the Alpha note already covers status, and "WIP" undersells the project.
- Add a CodeQL badge (workflow already exists, wasn't surfaced) — security scanning is a strong trust signal for an admin GUI handling tenant configuration.
- Remaining badges: CI, CodeQL, License, codecov.

## Test plan
- [x] Visual check of remaining badge markup renders correctly