### PR TITLE
docs: add WIP project status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/opendecree/decree-ui/actions/workflows/ci.yml/badge.svg)](https://github.com/opendecree/decree-ui/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/opendecree/decree-ui/actions/workflows/codeql.yml/badge.svg)](https://github.com/opendecree/decree-ui/actions/workflows/codeql.yml)
 [![License](https://img.shields.io/github/license/opendecree/decree-ui)](LICENSE)
+[![Project Status: WIP](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![codecov](https://codecov.io/gh/opendecree/decree-ui/graph/badge.svg)](https://codecov.io/gh/opendecree/decree-ui)
 
 A browser UI for [OpenDecree](https://github.com/opendecree/decree) — browse schemas, edit tenant config with validation and audit history,


### PR DESCRIPTION
## Summary

- Adds a `repostatus` **WIP** badge to the README, matching the Python, TypeScript, and demos READMEs which already show one.
- Part of the cross-repo badge-alignment sweep: every OpenDecree repo is alpha, so WIP is the consistent, honest maturity signal. (`decree` gets the same badge in a sibling PR.)

## Test plan

- [x] Markdown-only change; badge renders via repostatus.org
- [x] No code, tests, or generated files touched

Refs opendecree/decree#906