### PR TITLE
feat: redesign version history + diff

### DIFF
--- a/src/lib/__tests__/api-error.test.ts
+++ b/src/lib/__tests__/api-error.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { formatError, GRPC_CODE_ABORTED, isAbortedConflict } from "../api-error";
+import {
+	formatError,
+	GRPC_CODE_ABORTED,
+	GRPC_CODE_FAILED_PRECONDITION,
+	isAbortedConflict,
+	isRollbackRejected,
+} from "../api-error";
 
 describe("isAbortedConflict", () => {
 	it("recognises a gRPC ABORTED (code 10) status", () => {
@@ -31,6 +37,49 @@ describe("isAbortedConflict", () => {
 	it("returns false for an object with a non-string message and no matching code", () => {
 		expect(isAbortedConflict({ code: 5, message: 123 })).toBe(false);
 		expect(isAbortedConflict({})).toBe(false);
+	});
+});
+
+describe("isRollbackRejected", () => {
+	it("recognises a gRPC FAILED_PRECONDITION (code 9) status", () => {
+		expect(isRollbackRejected({ code: GRPC_CODE_FAILED_PRECONDITION, message: "blocked" })).toBe(
+			true,
+		);
+	});
+
+	it("falls back to the 'lock' message substring when the code is absent", () => {
+		expect(isRollbackRejected({ message: "field api.webhook_url is locked" })).toBe(true);
+	});
+
+	it("falls back to read-only / write-once message substrings (hyphen + space)", () => {
+		expect(isRollbackRejected({ message: "app.version is read-only" })).toBe(true);
+		expect(isRollbackRejected({ message: "app.version is read only" })).toBe(true);
+		expect(isRollbackRejected({ message: "currency is write-once" })).toBe(true);
+		expect(isRollbackRejected({ message: "currency is write once" })).toBe(true);
+	});
+
+	it("falls back to 'immutable' and 're-guard' / 'reguard' substrings", () => {
+		expect(isRollbackRejected({ message: "value is immutable" })).toBe(true);
+		expect(isRollbackRejected({ message: "re-guard failed" })).toBe(true);
+		expect(isRollbackRejected({ message: "reguard rejected" })).toBe(true);
+	});
+
+	it("does NOT mistake a concurrency conflict (ABORTED / checksum) for a rollback rejection", () => {
+		expect(isRollbackRejected({ code: GRPC_CODE_ABORTED, message: "checksum mismatch" })).toBe(
+			false,
+		);
+	});
+
+	it("returns false for an unrelated code + message", () => {
+		expect(isRollbackRejected({ code: 3, message: "invalid argument" })).toBe(false);
+	});
+
+	it("returns false for non-object / message-less / non-string-message errors", () => {
+		expect(isRollbackRejected(null)).toBe(false);
+		expect(isRollbackRejected("locked")).toBe(false);
+		expect(isRollbackRejected(undefined)).toBe(false);
+		expect(isRollbackRejected({})).toBe(false);
+		expect(isRollbackRejected({ code: 5, message: 123 })).toBe(false);
 	});
 });
 

--- a/src/lib/__tests__/diff.test.ts
+++ b/src/lib/__tests__/diff.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import type { components } from "../../api/schema";
+import { buildFieldDiffs, changeTypeOf, predictReguard } from "../diff";
+
+type AuditEntry = components["schemas"]["v1AuditEntry"];
+type SchemaField = components["schemas"]["v1SchemaField"];
+
+/** Build a path→field map from a flat field list (mirrors the screen's lookup). */
+function fieldMap(fields: SchemaField[]): Map<string, SchemaField> {
+	const m = new Map<string, SchemaField>();
+	for (const f of fields) if (f.path) m.set(f.path, f);
+	return m;
+}
+
+describe("changeTypeOf", () => {
+	it("is 'added' when only a new value is present", () => {
+		expect(changeTypeOf({ newValue: "3" })).toBe("added");
+		expect(changeTypeOf({ oldValue: undefined, newValue: "x" })).toBe("added");
+	});
+
+	it("is 'removed' when only an old value is present", () => {
+		expect(changeTypeOf({ oldValue: "3" })).toBe("removed");
+		expect(changeTypeOf({ oldValue: "x", newValue: undefined })).toBe("removed");
+	});
+
+	it("is 'modified' when both old and new values are present", () => {
+		expect(changeTypeOf({ oldValue: "1", newValue: "2" })).toBe("modified");
+	});
+
+	it("is 'modified' when neither side is present (defensive default)", () => {
+		expect(changeTypeOf({})).toBe("modified");
+	});
+
+	it("treats null the same as undefined (a stored-null is not a value here)", () => {
+		expect(changeTypeOf({ oldValue: null, newValue: "x" })).toBe("added");
+		expect(changeTypeOf({ oldValue: "x", newValue: null })).toBe("removed");
+	});
+});
+
+describe("buildFieldDiffs", () => {
+	const fields = fieldMap([
+		{ path: "app.name", type: "FIELD_TYPE_STRING" },
+		{ path: "payments.retries", type: "FIELD_TYPE_INT" },
+		{ path: "api.rate_limits", type: "FIELD_TYPE_JSON", sensitive: true },
+	]);
+
+	it("maps each field-mutating entry to a FieldDiff with the right change type", () => {
+		const entries: AuditEntry[] = [
+			{ fieldPath: "app.name", oldValue: "Old", newValue: "New" },
+			{ fieldPath: "payments.retries", newValue: "3" },
+		];
+		const diffs = buildFieldDiffs(entries, fields);
+		expect(diffs).toHaveLength(2);
+		const name = diffs.find((d) => d.path === "app.name");
+		expect(name).toMatchObject({ changeType: "modified", oldValue: "Old", newValue: "New" });
+		const retries = diffs.find((d) => d.path === "payments.retries");
+		expect(retries).toMatchObject({ changeType: "added", oldValue: null, newValue: "3" });
+	});
+
+	it("resolves sensitivity + field type from the schema by path", () => {
+		const diffs = buildFieldDiffs([{ fieldPath: "api.rate_limits", newValue: "x" }], fields);
+		expect(diffs[0]).toMatchObject({ sensitive: true, fieldType: "FIELD_TYPE_JSON" });
+	});
+
+	it("defaults sensitive=false and type=undefined for a path not in the schema", () => {
+		const diffs = buildFieldDiffs([{ fieldPath: "ghost.field", newValue: "x" }], fields);
+		expect(diffs[0].sensitive).toBe(false);
+		expect(diffs[0].fieldType).toBeUndefined();
+	});
+
+	it("skips entries with no field path (e.g. rollback marker entries)", () => {
+		const entries: AuditEntry[] = [
+			{ action: "rollback", newValue: "v2" },
+			{ fieldPath: "app.name", newValue: "New" },
+		];
+		const diffs = buildFieldDiffs(entries, fields);
+		expect(diffs).toHaveLength(1);
+		expect(diffs[0].path).toBe("app.name");
+	});
+
+	it("normalises a removed field to oldValue set / newValue null", () => {
+		const diffs = buildFieldDiffs([{ fieldPath: "app.name", oldValue: "Gone" }], fields);
+		expect(diffs[0]).toMatchObject({ changeType: "removed", oldValue: "Gone", newValue: null });
+	});
+
+	it("returns the diffs sorted by path for a stable render order", () => {
+		const entries: AuditEntry[] = [
+			{ fieldPath: "payments.retries", newValue: "3" },
+			{ fieldPath: "api.rate_limits", newValue: "x" },
+			{ fieldPath: "app.name", newValue: "n" },
+		];
+		const diffs = buildFieldDiffs(entries, fields);
+		expect(diffs.map((d) => d.path)).toEqual(["api.rate_limits", "app.name", "payments.retries"]);
+	});
+
+	it("returns an empty array for no entries", () => {
+		expect(buildFieldDiffs([], fields)).toEqual([]);
+	});
+});
+
+describe("predictReguard", () => {
+	const fields = fieldMap([
+		{ path: "app.name", type: "FIELD_TYPE_STRING", constraints: { maxLength: 10 } },
+		{ path: "payments.retries", type: "FIELD_TYPE_INT", constraints: { min: 0, max: 10 } },
+		{ path: "payments.currency", type: "FIELD_TYPE_STRING", writeOnce: true },
+		{ path: "app.version", type: "FIELD_TYPE_STRING", readOnly: true },
+	]);
+	const never = () => false;
+	const always = () => true;
+
+	it("returns no conflicts when every restored field is editable + valid", () => {
+		const restored = new Map([["payments.retries", "5"]]);
+		const conflicts = predictReguard("admin", restored, fields, new Set(), never);
+		expect(conflicts).toEqual([]);
+	});
+
+	it("flags a locked field for an admin (lock blocks non-superadmin)", () => {
+		const restored = new Map([["payments.retries", "5"]]);
+		const conflicts = predictReguard(
+			"admin",
+			restored,
+			fields,
+			new Set(["payments.retries"]),
+			never,
+		);
+		expect(conflicts).toEqual([{ path: "payments.retries", block: "locked" }]);
+	});
+
+	it("lets a superadmin bypass a lock (no conflict from the lock alone)", () => {
+		const restored = new Map([["payments.retries", "5"]]);
+		const conflicts = predictReguard(
+			"superadmin",
+			restored,
+			fields,
+			new Set(["payments.retries"]),
+			never,
+		);
+		expect(conflicts).toEqual([]);
+	});
+
+	it("flags read-only even for a superadmin (absolute lock)", () => {
+		const restored = new Map([["app.version", "9.9.9"]]);
+		const conflicts = predictReguard("superadmin", restored, fields, new Set(), never);
+		expect(conflicts).toEqual([{ path: "app.version", block: "read-only" }]);
+	});
+
+	it("flags write-once when the field currently holds a value — even for superadmin", () => {
+		const restored = new Map([["payments.currency", "EUR"]]);
+		const conflicts = predictReguard("superadmin", restored, fields, new Set(), always);
+		expect(conflicts).toEqual([{ path: "payments.currency", block: "write-once" }]);
+	});
+
+	it("permits a write-once restore when the field is currently unset", () => {
+		const restored = new Map([["payments.currency", "EUR"]]);
+		const conflicts = predictReguard("admin", restored, fields, new Set(), never);
+		expect(conflicts).toEqual([]);
+	});
+
+	it("flags 'role' for a user (no config-edit capability at all)", () => {
+		const restored = new Map([["payments.retries", "5"]]);
+		const conflicts = predictReguard("user", restored, fields, new Set(), never);
+		expect(conflicts).toEqual([{ path: "payments.retries", block: "role" }]);
+	});
+
+	it("flags an 'invalid' restore when the value violates a current constraint", () => {
+		const restored = new Map([["payments.retries", "999"]]);
+		const conflicts = predictReguard("admin", restored, fields, new Set(), never);
+		expect(conflicts).toHaveLength(1);
+		expect(conflicts[0].path).toBe("payments.retries");
+		expect(conflicts[0].block).toBe("invalid");
+		expect(conflicts[0].detail).toMatch(/maximum/i);
+	});
+
+	it("does not run validation once a field-level guard already blocks the field", () => {
+		// read-only takes precedence: block is "read-only", not "invalid".
+		const restored = new Map([["app.version", "x".repeat(50)]]);
+		const conflicts = predictReguard("admin", restored, fields, new Set(), never);
+		expect(conflicts).toEqual([{ path: "app.version", block: "read-only" }]);
+	});
+
+	it("skips a restored path that has no matching schema field", () => {
+		const restored = new Map([["ghost.field", "x"]]);
+		const conflicts = predictReguard("admin", restored, fields, new Set(), never);
+		expect(conflicts).toEqual([]);
+	});
+
+	it("returns conflicts sorted by path", () => {
+		const restored = new Map([
+			["payments.retries", "999"],
+			["app.version", "x"],
+		]);
+		const conflicts = predictReguard("admin", restored, fields, new Set(), never);
+		expect(conflicts.map((c) => c.path)).toEqual(["app.version", "payments.retries"]);
+	});
+});

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -10,6 +10,38 @@ type RpcStatus = components["schemas"]["rpcStatus"];
  */
 export const GRPC_CODE_ABORTED = 10;
 
+/**
+ * gRPC `FAILED_PRECONDITION` status code. `RollbackToVersion` re-guards every
+ * restored field server-side and rejects the whole rollback atomically when any
+ * one is locked / read-only / write-once / invalid under the *current* rules.
+ * The server surfaces that as FAILED_PRECONDITION (nothing is written).
+ */
+export const GRPC_CODE_FAILED_PRECONDITION = 9;
+
+/**
+ * Whether an API error is an atomic rollback rejection — the server re-guarded a
+ * restored field and refused the whole `RollbackToVersion`. Recognised by the
+ * `FAILED_PRECONDITION` gRPC code, with a message-text fallback (locked /
+ * read-only / write-once) so the surfacing still fires if a gateway drops the
+ * numeric code. Mirrors `isAbortedConflict`'s detection shape.
+ */
+export function isRollbackRejected(error: unknown): boolean {
+	if (!error || typeof error !== "object") return false;
+	const status = error as RpcStatus;
+	if (status.code === GRPC_CODE_FAILED_PRECONDITION) return true;
+	const msg = typeof status.message === "string" ? status.message.toLowerCase() : "";
+	return (
+		msg.includes("lock") ||
+		msg.includes("read-only") ||
+		msg.includes("read only") ||
+		msg.includes("write-once") ||
+		msg.includes("write once") ||
+		msg.includes("immutable") ||
+		msg.includes("re-guard") ||
+		msg.includes("reguard")
+	);
+}
+
 /** Extract a human-readable message from an API error body (rpcStatus) or unknown. */
 export function formatError(error: unknown): string {
 	if (error && typeof error === "object" && "message" in error) {

--- a/src/lib/diff.ts
+++ b/src/lib/diff.ts
@@ -1,0 +1,130 @@
+/**
+ * Pure helpers for the version-history diff.
+ *
+ * The REST gateway exposes no diff model and no full config snapshot at a
+ * historical version (`GetVersion` returns only metadata). The only per-version
+ * field-delta source is the audit log: every `SetField` write records an entry
+ * with `old_value`/`new_value` for the field it touched, tagged with the
+ * `config_version` it produced. So the per-version diff is computed *client-side*
+ * by collecting the audit entries that created a given version.
+ *
+ * Keeping the change-type derivation and the rollback re-guard prediction pure
+ * (no React, no DOM) makes them directly unit-testable — the backbone of the
+ * history screen's correctness.
+ */
+
+import type { components } from "../api/schema";
+import type { Role } from "./constants";
+import { type FieldEditBlock, fieldEditBlock } from "./permissions";
+import { validateField } from "./validation";
+
+type AuditEntry = components["schemas"]["v1AuditEntry"];
+type SchemaField = components["schemas"]["v1SchemaField"];
+
+/** What happened to a field between a version and its predecessor. */
+export type ChangeType = "added" | "removed" | "modified";
+
+/** A single field-level change within one config version. */
+export interface FieldDiff {
+	/** Dot-separated field path (e.g. "payments.fee_rate"). */
+	path: string;
+	changeType: ChangeType;
+	/** Predecessor value (raw audit string). `null` when the field was added. */
+	oldValue: string | null;
+	/** New value (raw audit string). `null` when the field was removed. */
+	newValue: string | null;
+	/**
+	 * Whether the field is sensitive in the schema. The server already redacts
+	 * sensitive values to the literal `[REDACTED]` on every read path, including
+	 * the audit log, so both sides must render redacted — never the raw string.
+	 */
+	sensitive: boolean;
+	/** The field type, for the type glyph (undefined if not in the schema). */
+	fieldType?: components["schemas"]["v1FieldType"];
+}
+
+/** Derive the change type from the presence of old/new values in an audit entry. */
+export function changeTypeOf(entry: Pick<AuditEntry, "oldValue" | "newValue">): ChangeType {
+	const hadOld = entry.oldValue !== undefined && entry.oldValue !== null;
+	const hasNew = entry.newValue !== undefined && entry.newValue !== null;
+	if (!hadOld && hasNew) return "added";
+	if (hadOld && !hasNew) return "removed";
+	return "modified";
+}
+
+/**
+ * Build the field-level diff for one config version from the audit entries that
+ * produced it. Only field-mutating entries (those carrying a `fieldPath`) are
+ * diffed; rollback marker entries (no field path) are skipped. Sensitivity and
+ * the type glyph are resolved from the schema by path.
+ */
+export function buildFieldDiffs(
+	entries: AuditEntry[],
+	fieldByPath: Map<string, SchemaField>,
+): FieldDiff[] {
+	const out: FieldDiff[] = [];
+	for (const e of entries) {
+		if (!e.fieldPath) continue;
+		const field = fieldByPath.get(e.fieldPath);
+		out.push({
+			path: e.fieldPath,
+			changeType: changeTypeOf(e),
+			oldValue: e.oldValue ?? null,
+			newValue: e.newValue ?? null,
+			sensitive: field?.sensitive ?? false,
+			fieldType: field?.type,
+		});
+	}
+	// Stable, predictable order for the diff body + tests.
+	out.sort((a, b) => a.path.localeCompare(b.path));
+	return out;
+}
+
+/** A field whose restore would be rejected when rolling back, with the reason. */
+export interface ReguardConflict {
+	path: string;
+	/** Why the restore is blocked (locked / read-only / write-once / role). */
+	block: FieldEditBlock | "invalid";
+	/** Validation message when the restored value is invalid under current rules. */
+	detail?: string;
+}
+
+/**
+ * Predict the server's atomic re-guard of a rollback. `RollbackToVersion`
+ * re-writes every field whose value differs from the current config, then
+ * re-guards each against the *current* rules; if any one is locked / read-only /
+ * write-once / invalid, the whole rollback is rejected (nothing written). This
+ * mirrors that guard chain client-side — routed through the same
+ * `fieldEditBlock` helper the config editor uses — so the UI can warn before the
+ * round-trip. The server stays the final authority.
+ *
+ * `restoredValues` is the set of fields the rollback would write (path -> the
+ * value being restored), already narrowed to those that differ from current.
+ */
+export function predictReguard(
+	role: Role,
+	restoredValues: Map<string, string>,
+	fieldByPath: Map<string, SchemaField>,
+	lockedPaths: Set<string>,
+	currentHasValue: (path: string) => boolean,
+): ReguardConflict[] {
+	const conflicts: ReguardConflict[] = [];
+	for (const [path, value] of restoredValues) {
+		const field = fieldByPath.get(path);
+		if (!field) continue;
+		const block = fieldEditBlock(role, field, {
+			hasValue: currentHasValue(path),
+			isLocked: lockedPaths.has(path),
+		});
+		if (block !== null) {
+			conflicts.push({ path, block });
+			continue;
+		}
+		// Field-level guards pass; the value must also still be valid under the
+		// current schema constraints (write-once/read-only already handled above).
+		const err = validateField(field, value);
+		if (err) conflicts.push({ path, block: "invalid", detail: err });
+	}
+	conflicts.sort((a, b) => a.path.localeCompare(b.path));
+	return conflicts;
+}

--- a/src/pages/tenants/TenantHistory.tsx
+++ b/src/pages/tenants/TenantHistory.tsx
@@ -1,38 +1,833 @@
-import { Link, useParams } from "react-router-dom";
-import { ConfigHistory } from "../../components/ConfigHistory";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useMemo, useState } from "react";
+import { useParams } from "react-router-dom";
+import type { components } from "../../api/schema";
+import { RedactedValue } from "../../components/FieldBadges";
+import { SkeletonDetail } from "../../components/Skeleton";
+import { formatError, isRollbackRejected } from "../../lib/api-error";
 import { useAuth } from "../../lib/auth";
-import { config } from "../../lib/config";
-import { useConfig, useTenant } from "../../lib/hooks";
-import { label } from "../../lib/labels";
+import type { Role } from "../../lib/constants";
+import {
+	buildFieldDiffs,
+	type ChangeType,
+	type FieldDiff,
+	predictReguard,
+	type ReguardConflict,
+} from "../../lib/diff";
+import { fieldTypeIcon, fieldTypeLabel } from "../../lib/field-types";
+import {
+	useApiClient,
+	useAuditLog,
+	useConfig,
+	useFieldLocks,
+	useSchemaVersion,
+	useTenant,
+	useVersions,
+} from "../../lib/hooks";
+import { canEditConfig } from "../../lib/permissions";
+import { useToast } from "../../lib/toast";
 
-/** Standalone config history page for a tenant. */
+type ConfigVersion = components["schemas"]["v1ConfigVersion"];
+type AuditEntry = components["schemas"]["v1AuditEntry"];
+type SchemaField = components["schemas"]["v1SchemaField"];
+
+/** Initials for an actor avatar — first two letters of the local part ("carol@acme" → "CA"). */
+function initials(actor: string): string {
+	const local = actor.split("@")[0] || actor;
+	return local.slice(0, 2).toUpperCase() || "?";
+}
+
+function formatWhen(iso: string | undefined): string {
+	if (!iso) return "";
+	const d = new Date(iso);
+	if (Number.isNaN(d.getTime())) return "";
+	return d.toLocaleString();
+}
+
+/** The action kind for a version, inferred from its description / audit marker. */
+type VersionAction = "create" | "rollback" | "set";
+
+/**
+ * Tokenized version history + diff (hi-fi Screen 4). A timeline of every
+ * `ConfigVersion` (the "why" captured at save), a field-level diff of the
+ * selected version against its predecessor, and a guarded rollback.
+ *
+ * The REST gateway returns no diff model and no historical config snapshot, so
+ * the per-version diff is computed client-side from the audit log (the only
+ * per-field delta source). Sensitive fields render `[REDACTED]` on both sides —
+ * the server never returns their value on any read path, the diff included.
+ *
+ * Rollback is a write: offered only to config editors (`canEditConfig`) and only
+ * on a non-current version. `RollbackToVersion` re-guards every restored field
+ * server-side and rejects the whole rollback atomically if any one is locked /
+ * read-only / write-once / invalid; this screen mirrors that guard chain (via the
+ * same `fieldEditBlock` helper) to warn first, and surfaces the server's atomic
+ * rejection — it never bypasses the server's authority.
+ */
 export function TenantHistory() {
 	const { id } = useParams<{ id: string }>();
-	const tid = id ?? "";
+	const tenantId = id ?? "";
 	const { auth } = useAuth();
-	const { data: tenantData } = useTenant(tid);
+	const role = auth.role;
+
+	const { data: tenantData, isLoading: tenantLoading, error: tenantError } = useTenant(tenantId);
 	const tenant = tenantData?.tenant;
-	const { data: configData } = useConfig(tid);
+
+	const { data: schemaData } = useSchemaVersion(tenant?.schemaId ?? "", tenant?.schemaVersion);
+	const schema = schemaData?.schema;
+
+	const { data: versionsData, isLoading: versionsLoading } = useVersions(tenantId);
+	const { data: configData } = useConfig(tenantId);
+	const { data: auditData } = useAuditLog(tenantId);
+	const { data: locksData } = useFieldLocks(tenantId);
+
+	const versions = useMemo<ConfigVersion[]>(() => versionsData?.versions ?? [], [versionsData]);
 	const currentVersion = configData?.config?.version;
 
+	const fieldByPath = useMemo(() => {
+		const m = new Map<string, SchemaField>();
+		for (const f of schema?.fields ?? []) {
+			if (f.path) m.set(f.path, f);
+		}
+		return m;
+	}, [schema]);
+
+	const lockedPaths = useMemo(() => {
+		const s = new Set<string>();
+		for (const lock of locksData?.locks ?? []) {
+			if (lock.fieldPath) s.add(lock.fieldPath);
+		}
+		return s;
+	}, [locksData]);
+
+	// Audit entries grouped by the version they produced — the diff source.
+	const entriesByVersion = useMemo(() => {
+		const m = new Map<number, AuditEntry[]>();
+		for (const e of auditData?.entries ?? []) {
+			if (e.configVersion === undefined) continue;
+			const list = m.get(e.configVersion) ?? [];
+			list.push(e);
+			m.set(e.configVersion, list);
+		}
+		return m;
+	}, [auditData]);
+
+	// Fields currently holding a value — drives the write-once re-guard prediction.
+	const currentValuePaths = useMemo(() => {
+		const s = new Set<string>();
+		for (const cv of configData?.config?.values ?? []) {
+			if (cv.fieldPath) s.add(cv.fieldPath);
+		}
+		return s;
+	}, [configData]);
+
+	// Default the selected version to the newest one.
+	const [selected, setSelected] = useState<number | null>(null);
+	const sortedVersions = useMemo(
+		() => [...versions].sort((a, b) => (b.version ?? 0) - (a.version ?? 0)),
+		[versions],
+	);
+	const effectiveSelected = selected ?? sortedVersions[0]?.version ?? currentVersion ?? null;
+
+	const selectedVersion = useMemo(
+		() => sortedVersions.find((v) => v.version === effectiveSelected),
+		[sortedVersions, effectiveSelected],
+	);
+
+	const diffs = useMemo<FieldDiff[]>(() => {
+		if (effectiveSelected === null) return [];
+		return buildFieldDiffs(entriesByVersion.get(effectiveSelected) ?? [], fieldByPath);
+	}, [effectiveSelected, entriesByVersion, fieldByPath]);
+
+	const isCurrent = effectiveSelected === currentVersion;
+	const showRollback = canEditConfig(role) && !isCurrent && effectiveSelected !== null;
+
+	// The fields a rollback to `selected` would re-write = those whose value at
+	// the target version differs from current. Resolve each field's value at the
+	// target by walking the audit deltas at-or-before that version (newest wins).
+	const restoredValues = useMemo(() => {
+		const m = new Map<string, string>();
+		if (effectiveSelected === null) return m;
+		// Walk every audit entry up to and including the target version, newest
+		// first, recording the first (most recent) value seen per field.
+		const upToTarget = (auditData?.entries ?? [])
+			.filter((e) => e.fieldPath && (e.configVersion ?? 0) <= effectiveSelected)
+			.sort((a, b) => (b.configVersion ?? 0) - (a.configVersion ?? 0));
+		const seen = new Set<string>();
+		const targetValues = new Map<string, string | null>();
+		for (const e of upToTarget) {
+			const path = e.fieldPath as string;
+			if (seen.has(path)) continue;
+			seen.add(path);
+			targetValues.set(path, e.newValue ?? null);
+		}
+		// Current resolved values, for the "differs from current" narrowing.
+		const currentValues = new Map<string, string>();
+		for (const cv of configData?.config?.values ?? []) {
+			if (cv.fieldPath) currentValues.set(cv.fieldPath, valueString(cv));
+		}
+		for (const [path, targetVal] of targetValues) {
+			if (targetVal === null) continue; // removed/never-set at target
+			if (currentValues.get(path) !== targetVal) m.set(path, targetVal);
+		}
+		return m;
+	}, [effectiveSelected, auditData, configData]);
+
+	const reguardConflicts = useMemo<ReguardConflict[]>(
+		() =>
+			predictReguard(role, restoredValues, fieldByPath, lockedPaths, (p) =>
+				currentValuePaths.has(p),
+			),
+		[role, restoredValues, fieldByPath, lockedPaths, currentValuePaths],
+	);
+
+	const client = useApiClient();
+	const queryClient = useQueryClient();
+	const { toast } = useToast();
+	const [confirmTarget, setConfirmTarget] = useState<number | null>(null);
+	const [note, setNote] = useState("");
+	const [rejection, setRejection] = useState<string | null>(null);
+
+	const rollbackMutation = useMutation({
+		mutationFn: async (version: number) => {
+			const { error } = await client.POST("/v1/tenants/{tenantId}/versions/{version}:rollback", {
+				params: {
+					path: { tenantId, version },
+					query: note ? { description: note } : {},
+				},
+			});
+			if (error) throw error;
+		},
+		onSuccess: () => {
+			setConfirmTarget(null);
+			setNote("");
+			setRejection(null);
+			setSelected(null); // jump back to newest (the new rollback version)
+			queryClient.invalidateQueries({ queryKey: ["config", tenantId] });
+			queryClient.invalidateQueries({ queryKey: ["versions", tenantId] });
+			queryClient.invalidateQueries({ queryKey: ["audit", tenantId] });
+			toast.success("Rollback committed — chain extended, audit entry recorded.");
+		},
+		onError: (err: unknown) => {
+			if (isRollbackRejected(err)) {
+				// Atomic re-guard rejection: nothing was written. Surface it in the
+				// modal rather than as a transient toast so the reason stays readable.
+				setRejection(formatError(err));
+				return;
+			}
+			toast.error(`Rollback failed: ${formatError(err)}`);
+		},
+	});
+
+	const openConfirm = useCallback(() => {
+		if (effectiveSelected === null) return;
+		setRejection(null);
+		setNote("");
+		setConfirmTarget(effectiveSelected);
+	}, [effectiveSelected]);
+
+	const isLoading = tenantLoading || versionsLoading;
+	if (isLoading) return <SkeletonDetail />;
+	if (tenantError) return <p className="text-danger">Error: {tenantError.message}</p>;
+	if (!tenant) return null;
+
 	return (
-		<div>
-			{config.layoutMode !== "single-tenant" && (
-				<div className="mb-6">
-					<Link
-						to={`/tenants/${tid}`}
-						className="text-sm text-blue-600 hover:underline dark:text-blue-400"
-					>
-						&larr; {label("common.back")} to {tenant?.name ?? "tenant"}
-					</Link>
+		<div data-testid="tenant-history" className="flex flex-col gap-5">
+			{/* Header */}
+			<div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-line pb-4">
+				<div className="min-w-0">
+					<h2 className="flex items-center gap-2 text-base font-semibold text-fg">
+						<svg
+							aria-hidden="true"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							className="h-4 w-4 text-fg-3"
+						>
+							<path d="M12 8v4l3 2" />
+							<circle cx="12" cy="12" r="9" />
+						</svg>
+						Version history
+					</h2>
+					<p className="mt-0.5 font-mono text-xs text-fg-3">
+						{tenant.name}
+						{schema && (
+							<>
+								{" · "}
+								{schema.name} v{tenant.schemaVersion}
+							</>
+						)}
+						{currentVersion !== undefined && <> · config v{currentVersion}</>}
+						{" · "}
+						{versions.length} version{versions.length === 1 ? "" : "s"}
+					</p>
+				</div>
+			</div>
+
+			{versions.length === 0 ? (
+				<p className="text-sm text-fg-3">No versions yet.</p>
+			) : (
+				<div className="flex flex-col gap-5 lg:flex-row">
+					{/* Timeline */}
+					<aside className="w-full shrink-0 lg:w-80">
+						<div className="mb-3 flex items-center gap-2">
+							<h3 className="text-sm font-semibold text-fg">Timeline</h3>
+							<span className="font-mono text-xs text-fg-3">{versions.length}</span>
+						</div>
+						<ol className="space-y-1.5" data-testid="version-timeline">
+							{sortedVersions.map((v) => (
+								<TimelineItem
+									key={v.version}
+									version={v}
+									action={actionOf(v)}
+									isCurrent={v.version === currentVersion}
+									isSelected={v.version === effectiveSelected}
+									onSelect={() => setSelected(v.version ?? null)}
+								/>
+							))}
+						</ol>
+					</aside>
+
+					{/* Diff pane */}
+					<section className="min-w-0 flex-1" data-testid="diff-pane">
+						<DiffHeader
+							selectedVersion={selectedVersion}
+							isEarliest={
+								effectiveSelected === Math.min(...sortedVersions.map((v) => v.version ?? 0))
+							}
+							changeCount={diffs.length}
+							showRollback={showRollback}
+							onRollback={openConfirm}
+						/>
+						<DiffBody diffs={diffs} />
+					</section>
 				</div>
 			)}
 
-			<h2 className="mb-4 text-xl font-semibold">
-				{label("config.history")} — {tenant?.name}
-			</h2>
+			{confirmTarget !== null && (
+				<RollbackModal
+					targetVersion={confirmTarget}
+					newVersion={(sortedVersions[0]?.version ?? confirmTarget) + 1}
+					changeCount={restoredValues.size}
+					role={role}
+					reguardConflicts={reguardConflicts}
+					rejection={rejection}
+					note={note}
+					onNote={setNote}
+					isPending={rollbackMutation.isPending}
+					onCancel={() => {
+						setConfirmTarget(null);
+						setRejection(null);
+					}}
+					onConfirm={() => rollbackMutation.mutate(confirmTarget)}
+				/>
+			)}
+		</div>
+	);
+}
 
-			<ConfigHistory tenantId={tid} currentVersion={currentVersion} role={auth.role} />
+/** Resolve a config value to its display string (the set member of the oneof). */
+function valueString(cv: components["schemas"]["v1ConfigValue"]): string {
+	const v = cv.value;
+	if (!v) return "";
+	if (v.stringValue !== undefined) return v.stringValue;
+	if (v.integerValue !== undefined) return String(v.integerValue);
+	if (v.numberValue !== undefined) return String(v.numberValue);
+	if (v.boolValue !== undefined) return String(v.boolValue);
+	if (v.timeValue !== undefined) return v.timeValue;
+	if (v.durationValue !== undefined) return v.durationValue;
+	if (v.urlValue !== undefined) return v.urlValue;
+	if (v.jsonValue !== undefined) return v.jsonValue;
+	return "";
+}
+
+/** Infer a version's action kind from its description (audit marker) text. */
+function actionOf(v: ConfigVersion): VersionAction {
+	const desc = (v.description ?? "").toLowerCase();
+	if (v.version === 1 || desc.includes("initial")) return "create";
+	if (desc.includes("rollback") || desc.includes("roll back")) return "rollback";
+	return "set";
+}
+
+const ACTION_STYLE: Record<VersionAction, { dot: string; badge: string }> = {
+	create: {
+		dot: "border-ok bg-ok-soft text-ok",
+		badge: "border-[color-mix(in_oklch,var(--ok)_35%,transparent)] bg-ok-soft text-ok",
+	},
+	rollback: {
+		dot: "border-warn bg-warn-soft text-warn",
+		badge: "border-[color-mix(in_oklch,var(--warn)_35%,transparent)] bg-warn-soft text-warn",
+	},
+	set: {
+		dot: "border-line-2 bg-surface-2 text-fg-2",
+		badge: "border-line-2 bg-surface-2 text-fg-2",
+	},
+};
+
+function TimelineItem({
+	version,
+	action,
+	isCurrent,
+	isSelected,
+	onSelect,
+}: {
+	version: ConfigVersion;
+	action: VersionAction;
+	isCurrent: boolean;
+	isSelected: boolean;
+	onSelect: () => void;
+}) {
+	const style = ACTION_STYLE[action];
+	const actor = version.createdBy ?? "unknown";
+	return (
+		<li>
+			<button
+				type="button"
+				onClick={onSelect}
+				aria-pressed={isSelected}
+				data-testid={`version-${version.version}`}
+				className={`flex w-full gap-3 rounded-[var(--r-md)] border p-2.5 text-left ${
+					isSelected
+						? "border-accent-line bg-accent-soft"
+						: "border-line bg-surface hover:bg-surface-2"
+				}`}
+			>
+				<span
+					className={`grid h-8 w-9 flex-none place-items-center rounded-[var(--r-sm)] border font-mono text-[11px] font-semibold ${style.dot}`}
+					aria-hidden="true"
+				>
+					v{version.version}
+				</span>
+				<span className="min-w-0 flex-1">
+					<span className="flex items-center gap-1.5">
+						<span className="text-sm font-medium text-fg">Version {version.version}</span>
+						{isCurrent && (
+							<span className="rounded-[var(--r-pill)] bg-accent-soft px-1.5 py-0.5 font-mono text-[10px] font-semibold text-accent">
+								current
+							</span>
+						)}
+						<span className="ml-auto whitespace-nowrap text-[11px] text-fg-3">
+							{formatWhen(version.createdAt)}
+						</span>
+					</span>
+					{version.description && (
+						<span className="mt-0.5 block truncate text-xs text-fg-2">{version.description}</span>
+					)}
+					<span className="mt-1 flex items-center gap-1.5 text-[11px] text-fg-3">
+						<span
+							className="grid h-4 w-4 flex-none place-items-center rounded-full bg-accent-soft font-mono text-[8px] font-semibold text-accent"
+							aria-hidden="true"
+						>
+							{initials(actor)}
+						</span>
+						<span className="truncate">{actor}</span>
+						{action !== "set" && (
+							<span
+								className={`ml-auto rounded-[var(--r-xs)] border px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-wide ${style.badge}`}
+							>
+								{action}
+							</span>
+						)}
+					</span>
+				</span>
+			</button>
+		</li>
+	);
+}
+
+function DiffHeader({
+	selectedVersion,
+	isEarliest,
+	changeCount,
+	showRollback,
+	onRollback,
+}: {
+	selectedVersion: ConfigVersion | undefined;
+	isEarliest: boolean;
+	changeCount: number;
+	showRollback: boolean;
+	onRollback: () => void;
+}) {
+	const target = selectedVersion?.version;
+	const baseLabel = isEarliest ? "∅" : `v${(target ?? 1) - 1}`;
+	const baseSub = isEarliest ? "initial" : "base";
+	return (
+		<div className="mb-4 flex flex-wrap items-center gap-3 rounded-[var(--r-md)] border border-line bg-surface-2 px-3 py-2.5">
+			<div className="flex items-center gap-2">
+				<span className="flex flex-col items-center rounded-[var(--r-sm)] border border-line bg-surface px-2.5 py-1">
+					<span className="font-mono text-sm font-semibold text-fg">{baseLabel}</span>
+					<span className="font-mono text-[9px] uppercase tracking-wide text-fg-3">{baseSub}</span>
+				</span>
+				<span className="text-fg-3" aria-hidden="true">
+					→
+				</span>
+				<span className="flex flex-col items-center rounded-[var(--r-sm)] border border-accent-line bg-accent-soft px-2.5 py-1">
+					<span className="font-mono text-sm font-semibold text-fg">v{target}</span>
+					<span className="font-mono text-[9px] uppercase tracking-wide text-fg-3">compare</span>
+				</span>
+			</div>
+			<span className="font-mono text-xs text-fg-2" data-testid="diff-summary">
+				<b className="text-fg">{changeCount}</b> field{changeCount === 1 ? "" : "s"} changed
+			</span>
+			<span className="flex-1" />
+			{showRollback && (
+				<button
+					type="button"
+					onClick={onRollback}
+					data-testid="rollback-button"
+					className="inline-flex items-center gap-1.5 rounded-[var(--r-sm)] border border-line-2 bg-surface-2 px-3 py-1.5 text-xs font-medium text-fg hover:bg-surface-3"
+				>
+					<svg
+						aria-hidden="true"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						className="h-3.5 w-3.5"
+					>
+						<path d="M9 14 4 9l5-5" />
+						<path d="M4 9h11a6 6 0 0 1 0 12h-3" />
+					</svg>
+					Roll back to this
+				</button>
+			)}
+		</div>
+	);
+}
+
+function DiffBody({ diffs }: { diffs: FieldDiff[] }) {
+	if (diffs.length === 0) {
+		return (
+			<div
+				data-testid="diff-empty"
+				className="flex flex-col items-center gap-2 rounded-[var(--r-md)] border border-dashed border-line py-12 text-fg-3"
+			>
+				<svg
+					aria-hidden="true"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="2"
+					className="h-6 w-6"
+				>
+					<path d="M5 12l5 5L20 7" />
+				</svg>
+				<p className="text-sm">No field changes between these versions.</p>
+			</div>
+		);
+	}
+	return (
+		<div className="space-y-2">
+			{diffs.map((d) => (
+				<DiffRow key={d.path} diff={d} />
+			))}
+		</div>
+	);
+}
+
+const CHANGE_STYLE: Record<ChangeType, string> = {
+	added: "border-[color-mix(in_oklch,var(--ok)_35%,transparent)] bg-ok-soft text-ok",
+	removed: "border-[color-mix(in_oklch,var(--danger)_35%,transparent)] bg-danger-soft text-danger",
+	modified: "border-accent-line bg-accent-soft text-accent",
+};
+
+function DiffRow({ diff }: { diff: FieldDiff }) {
+	const title = diff.path
+		.split(".")
+		.pop()
+		?.replace(/_/g, " ")
+		.replace(/\b\w/g, (c) => c.toUpperCase());
+	return (
+		<div
+			data-testid={`diff-${diff.path}`}
+			className="grid grid-cols-[2.25rem_1fr] gap-3 rounded-[var(--r-md)] border border-line bg-surface p-3"
+		>
+			<span
+				title={fieldTypeLabel(diff.fieldType)}
+				className="flex h-7 w-9 items-center justify-center rounded-[var(--r-sm)] border border-line-2 bg-surface-2 font-mono text-[10px] font-medium text-fg-2"
+			>
+				{diff.fieldType ? fieldTypeIcon(diff.fieldType) : "·"}
+			</span>
+			<div className="min-w-0">
+				<div className="flex flex-wrap items-center gap-2">
+					<span className="text-sm font-medium text-fg">{title}</span>
+					<code className="font-mono text-xs text-fg-3">{diff.path}</code>
+					<span
+						className={`rounded-[var(--r-xs)] border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide ${CHANGE_STYLE[diff.changeType]}`}
+					>
+						{diff.changeType}
+					</span>
+					{diff.sensitive && (
+						<span className="inline-flex items-center gap-1 rounded-[var(--r-xs)] border border-line-2 bg-surface-2 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-fg-2">
+							<svg
+								aria-hidden="true"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								className="h-2.5 w-2.5"
+							>
+								<path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7z" />
+								<circle cx="12" cy="12" r="2.5" />
+							</svg>
+							sensitive
+						</span>
+					)}
+				</div>
+				<div className="mt-2 grid grid-cols-[1fr_auto_1fr] items-center gap-2">
+					<DiffValue side="old" diff={diff} />
+					<svg
+						aria-hidden="true"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						className="h-4 w-4 text-fg-3"
+					>
+						<path d="M5 12h14M13 6l6 6-6 6" />
+					</svg>
+					<DiffValue side="new" diff={diff} />
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function DiffValue({ side, diff }: { side: "old" | "new"; diff: FieldDiff }) {
+	const isEmpty =
+		(side === "old" && diff.changeType === "added") ||
+		(side === "new" && diff.changeType === "removed");
+	const raw = side === "old" ? diff.oldValue : diff.newValue;
+
+	const tone =
+		side === "old"
+			? "border-line bg-surface-2"
+			: diff.changeType === "removed"
+				? "border-line bg-surface-2"
+				: "border-accent-line bg-accent-soft";
+
+	return (
+		<div
+			data-testid={`diff-${diff.path}-${side}`}
+			className={`flex min-w-0 items-center gap-2 overflow-hidden rounded-[var(--r-sm)] border px-2.5 py-1.5 ${tone}`}
+		>
+			<span className="font-mono text-[9px] uppercase tracking-wide text-fg-3">
+				{side === "old" ? "old" : "new"}
+			</span>
+			{isEmpty ? (
+				<span className="font-mono text-xs text-fg-3 italic">
+					{side === "old" ? "did not exist" : "removed"}
+				</span>
+			) : diff.sensitive ? (
+				// Sensitive: never reveal either side — the server hard-redacts on every
+				// read path, the diff included. Render [REDACTED] on both sides.
+				<RedactedValue />
+			) : raw === null ? (
+				<span className="font-mono text-xs text-fg-3">null</span>
+			) : (
+				<code className="truncate font-mono text-xs text-fg">{raw}</code>
+			)}
+		</div>
+	);
+}
+
+const BLOCK_REASON: Record<ReguardConflict["block"], string> = {
+	role: "no access",
+	"read-only": "read-only",
+	"write-once": "write-once",
+	locked: "locked",
+	invalid: "invalid under current schema",
+};
+
+function RollbackModal({
+	targetVersion,
+	newVersion,
+	changeCount,
+	role,
+	reguardConflicts,
+	rejection,
+	note,
+	onNote,
+	isPending,
+	onCancel,
+	onConfirm,
+}: {
+	targetVersion: number;
+	newVersion: number;
+	changeCount: number;
+	role: Role;
+	reguardConflicts: ReguardConflict[];
+	rejection: string | null;
+	note: string;
+	onNote: (v: string) => void;
+	isPending: boolean;
+	onCancel: () => void;
+	onConfirm: () => void;
+}) {
+	const willReject = reguardConflicts.length > 0;
+	return (
+		<div
+			role="dialog"
+			aria-modal="true"
+			aria-label={`Roll back to version ${targetVersion}`}
+			data-testid="rollback-modal"
+			className="fixed inset-0 z-50 flex items-center justify-center p-4"
+		>
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: backdrop dismiss */}
+			<div
+				role="presentation"
+				className="absolute inset-0 bg-black/40"
+				onClick={isPending ? undefined : onCancel}
+			/>
+			<div className="relative flex max-h-[85vh] w-full max-w-lg flex-col overflow-hidden rounded-[var(--r-lg)] border border-line-2 bg-surface shadow-[var(--sh-2)]">
+				<header className="flex items-start gap-3 border-b border-line px-5 py-4">
+					<svg
+						aria-hidden="true"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						className="mt-0.5 h-5 w-5 flex-none text-warn"
+					>
+						<path d="M12 9v4m0 4h.01M10.3 3.9 2.4 18a2 2 0 0 0 1.7 3h15.8a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z" />
+					</svg>
+					<h2 className="text-sm font-semibold text-fg">
+						Roll back to <span className="font-mono">v{targetVersion}</span>?
+					</h2>
+				</header>
+
+				<div className="min-h-0 flex-1 space-y-3 overflow-y-auto px-5 py-4 text-xs text-fg-2">
+					<p>
+						This creates a <b className="font-semibold text-fg">new version</b> (
+						<span className="font-mono">v{newVersion}</span>) whose values match{" "}
+						<span className="font-mono">v{targetVersion}</span> — history is never rewritten, and
+						the rollback itself is recorded in the audit chain.{" "}
+						<b className="font-semibold text-fg">{changeCount}</b> field
+						{changeCount === 1 ? "" : "s"} will change from the current version.
+					</p>
+					<p className="flex items-start gap-2 text-fg-3">
+						<svg
+							aria-hidden="true"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							className="mt-0.5 h-3.5 w-3.5 flex-none"
+						>
+							<path d="M12 3l8 4v5c0 5-3.5 7.5-8 9-4.5-1.5-8-4-8-9V7z" />
+						</svg>
+						<span>
+							Each restored field is <b className="font-semibold text-fg-2">re-guarded</b> against
+							current rules (locks, read-only, write-once, validity). If any fails, the whole
+							rollback is <b className="font-semibold text-fg-2">rejected atomically</b> — nothing
+							is written.
+						</span>
+					</p>
+
+					{/* Server's atomic rejection (final authority) takes precedence. */}
+					{rejection ? (
+						<div
+							data-testid="rollback-rejected"
+							className="flex items-start gap-2 rounded-[var(--r-sm)] border border-[color-mix(in_oklch,var(--danger)_45%,transparent)] bg-danger-soft px-3 py-2.5 text-danger"
+						>
+							<svg
+								aria-hidden="true"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								className="mt-0.5 h-4 w-4 flex-none"
+							>
+								<circle cx="12" cy="12" r="9" />
+								<path d="M12 8v4m0 4h.01" />
+							</svg>
+							<span>
+								<b className="block font-semibold">Rollback rejected — nothing written.</b>
+								<span className="text-fg-2">
+									The server re-guarded the restored fields and refused the whole write. {rejection}
+								</span>
+							</span>
+						</div>
+					) : willReject ? (
+						// Client-side mirror of the guard chain — a heads-up before the round-trip.
+						<div
+							data-testid="rollback-warning"
+							className="rounded-[var(--r-sm)] border border-[color-mix(in_oklch,var(--warn)_30%,transparent)] bg-warn-soft px-3 py-2.5 text-warn"
+						>
+							<span className="flex items-start gap-2">
+								<svg
+									aria-hidden="true"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="2"
+									className="mt-0.5 h-4 w-4 flex-none"
+								>
+									<path d="M12 9v4m0 4h.01M10.3 3.9 2.4 18a2 2 0 0 0 1.7 3h15.8a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z" />
+								</svg>
+								<span>
+									This rollback will likely be <b className="font-semibold">rejected atomically</b>{" "}
+									— the following restored field{reguardConflicts.length === 1 ? " is" : "s are"}{" "}
+									guarded under current rules
+									{role === "admin" ? " (a superadmin can bypass locks)" : ""}:
+								</span>
+							</span>
+							<ul className="mt-2 space-y-1">
+								{reguardConflicts.map((c) => (
+									<li key={c.path} className="flex items-center gap-2 font-mono text-[11px]">
+										<code className="text-fg-2">{c.path}</code>
+										<span className="rounded-[var(--r-xs)] border border-[color-mix(in_oklch,var(--warn)_35%,transparent)] px-1.5 py-0.5 uppercase tracking-wide">
+											{BLOCK_REASON[c.block]}
+										</span>
+									</li>
+								))}
+							</ul>
+						</div>
+					) : null}
+
+					<input
+						value={note}
+						onChange={(e) => onNote(e.target.value)}
+						placeholder={`Version note — why roll back? (recorded on v${newVersion})`}
+						aria-label="Rollback version note"
+						className="w-full rounded-[var(--r-sm)] border border-line-2 bg-canvas px-3 py-1.5 text-sm text-fg outline-none focus:border-accent"
+					/>
+				</div>
+
+				<footer className="flex items-center gap-2 border-t border-line px-5 py-3">
+					<span className="flex-1" />
+					<button
+						type="button"
+						onClick={onCancel}
+						disabled={isPending}
+						className="rounded-[var(--r-sm)] border border-line-2 bg-surface-2 px-3 py-1.5 text-sm font-medium text-fg hover:bg-surface-3 disabled:opacity-50"
+					>
+						{rejection ? "Close" : "Cancel"}
+					</button>
+					{!rejection && (
+						<button
+							type="button"
+							onClick={onConfirm}
+							disabled={isPending}
+							className="inline-flex items-center gap-2 rounded-[var(--r-sm)] bg-accent px-4 py-1.5 text-sm font-semibold text-accent-fg hover:brightness-110 disabled:opacity-50"
+						>
+							<svg
+								aria-hidden="true"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								className="h-3.5 w-3.5"
+							>
+								<path d="M9 14 4 9l5-5" />
+								<path d="M4 9h11a6 6 0 0 1 0 12h-3" />
+							</svg>
+							{isPending ? "Rolling back…" : "Create rollback version"}
+						</button>
+					)}
+				</footer>
+			</div>
 		</div>
 	);
 }

--- a/src/pages/tenants/__tests__/TenantHistory.test.tsx
+++ b/src/pages/tenants/__tests__/TenantHistory.test.tsx
@@ -1,0 +1,465 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { type ReactNode, useState } from "react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../../../api/schema";
+import { AuthContext, type AuthContextValue } from "../../../lib/auth";
+import type { Role } from "../../../lib/constants";
+import { ToastProvider } from "../../../lib/toast";
+import { TenantHistory } from "../TenantHistory";
+
+type SchemaField = components["schemas"]["v1SchemaField"];
+type ConfigVersion = components["schemas"]["v1ConfigVersion"];
+type AuditEntry = components["schemas"]["v1AuditEntry"];
+
+const TENANT_ID = "00000000-0000-0000-0000-000000000001";
+
+const tenant = { id: TENANT_ID, name: "Acme Corp", schemaId: "s1", schemaVersion: 1 };
+
+const fields: SchemaField[] = [
+	{ path: "app.name", type: "FIELD_TYPE_STRING" },
+	{ path: "payments.fee_rate", type: "FIELD_TYPE_NUMBER" },
+	{ path: "payments.enabled", type: "FIELD_TYPE_BOOL" },
+	{ path: "payments.retries", type: "FIELD_TYPE_INT" },
+	{ path: "settlement.window", type: "FIELD_TYPE_DURATION" },
+	{ path: "flags.cutover", type: "FIELD_TYPE_TIME" },
+	{ path: "api.webhook_url", type: "FIELD_TYPE_URL" },
+	{ path: "api.rate_limits", type: "FIELD_TYPE_JSON", sensitive: true },
+];
+
+// Newest first, mixing set / rollback / create so the timeline badges render.
+// v2 uses the spaced "roll back" spelling; v1 has no "initial"/version marker but
+// is version 1 → still classified as a create (exercises the version===1 branch).
+const versions: ConfigVersion[] = [
+	{
+		version: 8,
+		description: "Re-enable payments module",
+		createdBy: "carol@acme",
+		createdAt: "2026-06-15T10:01:00Z",
+	},
+	{ version: 7, description: "Bump fee rate for Q2", createdBy: "alice@acme" },
+	{ version: 6, description: "Enable payments module", createdBy: "alice@acme" },
+	{ version: 5, description: "Rollback to version 3", createdBy: "bob@acme" },
+	// v4 has no audit deltas in the fixture → exercises the empty-diff state.
+	{ version: 4, description: "No-op administrative bump", createdBy: "bob@acme" },
+	{ version: 3, description: "Initial production values", createdBy: "alice@acme" },
+	{ version: 2, description: "Roll back to version 1", createdBy: "bob@acme" },
+	{ version: 1, description: "", createdBy: undefined },
+];
+
+// Audit entries, tagged with the config version they produced.
+const auditEntries: AuditEntry[] = [
+	{ fieldPath: "payments.enabled", oldValue: "false", newValue: "true", configVersion: 8 },
+	{ fieldPath: "app.name", oldValue: "MyApp", newValue: "OpenDecree Demo", configVersion: 7 },
+	{ fieldPath: "payments.fee_rate", oldValue: "1.0", newValue: "2.5", configVersion: 7 },
+	// A removed field at v6 → exercises the "removed" change-type + empty new side.
+	{ fieldPath: "settlement.window", oldValue: "48h", configVersion: 6 },
+	{ fieldPath: "payments.retries", newValue: "3", configVersion: 6 },
+	{ fieldPath: "api.rate_limits", newValue: "[REDACTED]", configVersion: 6 },
+	{
+		fieldPath: "api.webhook_url",
+		oldValue: "https://staging.example.com/wh",
+		newValue: "https://old.example.com/wh",
+		configVersion: 5,
+	},
+	// A no-field rollback marker entry → must be skipped by the diff builder.
+	{ action: "rollback", newValue: "v3", configVersion: 5 },
+	{ fieldPath: "app.name", newValue: "MyApp", configVersion: 3 },
+	{ fieldPath: "payments.fee_rate", newValue: "1.0", configVersion: 3 },
+	{ fieldPath: "flags.cutover", newValue: "2025-01-15T09:30:00Z", configVersion: 1 },
+	// An entry with no configVersion → must be excluded from the per-version grouping.
+	{ fieldPath: "app.name", newValue: "stray", actor: "system" },
+];
+
+// Current resolved config (v8). One value per oneof member, so valueString covers
+// every type branch. webhook_url currently differs from its v5 value (and is
+// locked), so a rollback to v5 would re-write it.
+const configValues = [
+	{ fieldPath: "payments.enabled", value: { boolValue: true } },
+	{ fieldPath: "app.name", value: { stringValue: "OpenDecree Demo" } },
+	{ fieldPath: "payments.fee_rate", value: { numberValue: 2.5 } },
+	{ fieldPath: "payments.retries", value: { integerValue: "3" } },
+	{ fieldPath: "settlement.window", value: { durationValue: "24h" } },
+	{ fieldPath: "flags.cutover", value: { timeValue: "2025-01-15T09:30:00Z" } },
+	{ fieldPath: "api.webhook_url", value: { urlValue: "https://current.example.com/wh" } },
+	{ fieldPath: "api.rate_limits", value: { jsonValue: "[REDACTED]" } },
+	{ fieldPath: "orphan.novalue", value: {} }, // empty oneof → valueString "" fallback
+	{ fieldPath: "orphan.missing" }, // no value at all → skipped
+];
+
+// Mutable per-test state so loading / error / empty branches can be exercised.
+const state = {
+	tenant: { data: { tenant }, isLoading: false, error: null as Error | null },
+	versions: { data: { versions } as { versions?: ConfigVersion[] }, isLoading: false },
+	config: { data: { config: { version: 8 as number | undefined, values: configValues } } },
+	audit: { data: { entries: auditEntries } },
+	locks: { data: { locks: [] as { fieldPath: string }[] } },
+};
+const mockClient = { POST: vi.fn(), GET: vi.fn() };
+
+vi.mock("../../../lib/hooks", () => ({
+	useApiClient: () => mockClient,
+	useTenant: () => state.tenant,
+	useSchemaVersion: () => ({ data: { schema: { name: "showcase", fields } }, isLoading: false }),
+	useVersions: () => state.versions,
+	useConfig: () => state.config,
+	useAuditLog: () => state.audit,
+	useFieldLocks: () => state.locks,
+}));
+
+beforeEach(() => {
+	state.tenant = { data: { tenant }, isLoading: false, error: null };
+	state.versions = { data: { versions }, isLoading: false };
+	state.config = { data: { config: { version: 8, values: configValues } } };
+	state.audit = { data: { entries: auditEntries } };
+	state.locks = { data: { locks: [] } };
+	mockClient.POST.mockReset();
+	mockClient.GET.mockReset();
+});
+
+function renderHistory(role: Role = "admin") {
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	function Harness({ children }: { children: ReactNode }) {
+		const [auth] = useState({ subject: "carol", role, tenantId: TENANT_ID });
+		const ctx: AuthContextValue = { auth, setAuth: () => {} };
+		return <AuthContext value={ctx}>{children}</AuthContext>;
+	}
+	return render(
+		<QueryClientProvider client={qc}>
+			<ToastProvider>
+				<Harness>
+					<MemoryRouter initialEntries={[`/tenants/${TENANT_ID}/history`]}>
+						<Routes>
+							<Route path="/tenants/:id/history" element={<TenantHistory />} />
+						</Routes>
+					</MemoryRouter>
+				</Harness>
+			</ToastProvider>
+		</QueryClientProvider>,
+	);
+}
+
+/** Select a timeline version by its number. */
+function selectVersion(v: number) {
+	fireEvent.click(screen.getByTestId(`version-${v}`));
+}
+
+/** Open the rollback modal for the currently-selected (non-current) version. */
+function openRollback() {
+	fireEvent.click(screen.getByTestId("rollback-button"));
+	return screen.getByTestId("rollback-modal");
+}
+
+describe("TenantHistory — render + timeline", () => {
+	it("renders the tenant + schema header and a timeline item per version", () => {
+		renderHistory();
+		expect(screen.getByTestId("tenant-history")).toBeInTheDocument();
+		// Name + schema + current version live in one header line (adjacent text nodes).
+		expect(screen.getByText(/Acme Corp · showcase v1 · config v8/)).toBeInTheDocument();
+		const timeline = screen.getByTestId("version-timeline");
+		for (const v of [8, 7, 6, 5, 4, 3, 2, 1]) {
+			expect(within(timeline).getByTestId(`version-${v}`)).toBeInTheDocument();
+		}
+	});
+
+	it("marks the current version and shows action badges for create/rollback", () => {
+		renderHistory();
+		// v8 is current and selected by default.
+		const v8 = screen.getByTestId("version-8");
+		expect(within(v8).getByText("current")).toBeInTheDocument();
+		expect(v8).toHaveAttribute("aria-pressed", "true");
+		// v3 = create badge, v5 = rollback badge.
+		expect(within(screen.getByTestId("version-3")).getByText("create")).toBeInTheDocument();
+		expect(within(screen.getByTestId("version-5")).getByText("rollback")).toBeInTheDocument();
+	});
+
+	it("defaults the diff to the newest version against its predecessor", () => {
+		renderHistory();
+		const pane = screen.getByTestId("diff-pane");
+		// v8 modifies payments.enabled only.
+		expect(within(pane).getByTestId("diff-payments.enabled")).toBeInTheDocument();
+		expect(within(pane).getByTestId("diff-summary")).toHaveTextContent("1 field changed");
+	});
+});
+
+describe("TenantHistory — diff rendering", () => {
+	it("shows a per-field old→new diff with the change-type tag", () => {
+		renderHistory();
+		selectVersion(7);
+		const row = screen.getByTestId("diff-payments.fee_rate");
+		expect(within(row).getByText("modified")).toBeInTheDocument();
+		expect(within(screen.getByTestId("diff-payments.fee_rate-old")).getByText("1.0")).toBeTruthy();
+		expect(within(screen.getByTestId("diff-payments.fee_rate-new")).getByText("2.5")).toBeTruthy();
+	});
+
+	it("renders an added field with a 'did not exist' old side", () => {
+		renderHistory();
+		selectVersion(6);
+		const row = screen.getByTestId("diff-payments.retries");
+		expect(within(row).getByText("added")).toBeInTheDocument();
+		expect(
+			within(screen.getByTestId("diff-payments.retries-old")).getByText(/did not exist/),
+		).toBeInTheDocument();
+		expect(within(screen.getByTestId("diff-payments.retries-new")).getByText("3")).toBeTruthy();
+	});
+
+	it("keeps a sensitive field [REDACTED] on BOTH sides of the diff", () => {
+		renderHistory();
+		selectVersion(6);
+		const row = screen.getByTestId("diff-api.rate_limits");
+		expect(within(row).getByText("sensitive")).toBeInTheDocument();
+		// Both the old and the new value cells render the redaction, never cleartext.
+		const oldCell = screen.getByTestId("diff-api.rate_limits-old");
+		const newCell = screen.getByTestId("diff-api.rate_limits-new");
+		// "added" → old side is the empty placeholder; new side must be redacted.
+		expect(within(newCell).getByText("[REDACTED]")).toBeInTheDocument();
+		// The empty/placeholder side must not leak a value either.
+		expect(within(oldCell).queryByText(/example|http|\{/)).toBeNull();
+	});
+
+	it("shows the empty-diff state when a version has no field changes", () => {
+		renderHistory();
+		selectVersion(4); // v4 has no audit deltas in the fixture
+		expect(screen.getByTestId("diff-empty")).toBeInTheDocument();
+		expect(screen.getByTestId("diff-summary")).toHaveTextContent("0 fields changed");
+	});
+});
+
+describe("TenantHistory — rollback gating", () => {
+	it("offers rollback to an admin on a non-current version", () => {
+		renderHistory("admin");
+		selectVersion(7);
+		expect(screen.getByTestId("rollback-button")).toBeInTheDocument();
+	});
+
+	it("hides rollback on the current version", () => {
+		renderHistory("admin");
+		// v8 is current + selected by default.
+		expect(screen.queryByTestId("rollback-button")).toBeNull();
+	});
+
+	it("never offers rollback to a user (absent, not disabled)", () => {
+		renderHistory("user");
+		selectVersion(7);
+		expect(screen.queryByTestId("rollback-button")).toBeNull();
+	});
+
+	it("offers rollback to a superadmin on a non-current version", () => {
+		renderHistory("superadmin");
+		selectVersion(7);
+		expect(screen.getByTestId("rollback-button")).toBeInTheDocument();
+	});
+});
+
+describe("TenantHistory — re-guard prediction (client-side mirror)", () => {
+	it("warns before the round-trip when a restored field is locked (admin)", () => {
+		state.locks = { data: { locks: [{ fieldPath: "api.webhook_url" }] } };
+		renderHistory("admin");
+		selectVersion(5); // v5 set webhook_url to a value differing from current → re-write
+		openRollback();
+		const warning = screen.getByTestId("rollback-warning");
+		expect(warning).toHaveTextContent(/rejected atomically/i);
+		expect(within(warning).getByText("api.webhook_url")).toBeInTheDocument();
+		expect(within(warning).getByText("locked")).toBeInTheDocument();
+	});
+
+	it("shows no re-guard warning for a superadmin who bypasses the lock", () => {
+		state.locks = { data: { locks: [{ fieldPath: "api.webhook_url" }] } };
+		renderHistory("superadmin");
+		selectVersion(5);
+		openRollback();
+		expect(screen.queryByTestId("rollback-warning")).toBeNull();
+	});
+
+	it("shows no warning when the restored fields are all editable", () => {
+		renderHistory("admin");
+		selectVersion(7); // fee_rate + app.name, neither locked
+		openRollback();
+		expect(screen.queryByTestId("rollback-warning")).toBeNull();
+	});
+});
+
+describe("TenantHistory — rollback commit + atomic rejection", () => {
+	it("commits a rollback and posts to the rollback endpoint with the note", async () => {
+		mockClient.POST.mockResolvedValue({ data: {}, error: undefined });
+		renderHistory("admin");
+		selectVersion(7);
+		openRollback();
+		fireEvent.change(screen.getByLabelText("Rollback version note"), {
+			target: { value: "revert Q2 fee bump" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /Create rollback version/ }));
+		await waitFor(() => expect(mockClient.POST).toHaveBeenCalledTimes(1));
+		const [path, opts] = mockClient.POST.mock.calls[0];
+		expect(path).toBe("/v1/tenants/{tenantId}/versions/{version}:rollback");
+		expect(opts.params.path).toEqual({ tenantId: TENANT_ID, version: 7 });
+		expect(opts.params.query).toEqual({ description: "revert Q2 fee bump" });
+		// Modal closes on success.
+		await waitFor(() => expect(screen.queryByTestId("rollback-modal")).toBeNull());
+	});
+
+	it("surfaces an atomic re-guard rejection (FAILED_PRECONDITION) distinctly, without writing", async () => {
+		mockClient.POST.mockResolvedValue({
+			data: undefined,
+			error: { code: 9, message: "field api.webhook_url is locked" },
+		});
+		renderHistory("admin");
+		selectVersion(5);
+		openRollback();
+		fireEvent.click(screen.getByRole("button", { name: /Create rollback version/ }));
+		const rejected = await screen.findByTestId("rollback-rejected");
+		expect(rejected).toHaveTextContent(/Rollback rejected — nothing written/);
+		expect(rejected).toHaveTextContent(/api.webhook_url is locked/);
+		// Distinct from a concurrency conflict: no rebase/conflict resolver is shown.
+		expect(screen.queryByTestId("conflict-resolver")).toBeNull();
+		// The modal stays open showing the reason; the confirm button is gone.
+		expect(screen.getByTestId("rollback-modal")).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: /Create rollback version/ })).toBeNull();
+		expect(screen.getByRole("button", { name: /Close/ })).toBeInTheDocument();
+	});
+
+	it("cancelling the modal closes it without posting", () => {
+		renderHistory("admin");
+		selectVersion(7);
+		openRollback();
+		fireEvent.click(screen.getByRole("button", { name: /Cancel/ }));
+		expect(screen.queryByTestId("rollback-modal")).toBeNull();
+		expect(mockClient.POST).not.toHaveBeenCalled();
+	});
+
+	it("shows a toast (not the rejected banner) for a non-rollback-rejection error", async () => {
+		mockClient.POST.mockResolvedValue({
+			data: undefined,
+			error: { code: 13, message: "internal error" },
+		});
+		renderHistory("admin");
+		selectVersion(7);
+		openRollback();
+		fireEvent.click(screen.getByRole("button", { name: /Create rollback version/ }));
+		expect(await screen.findByText(/Rollback failed: internal error/)).toBeInTheDocument();
+		// A generic failure is not the atomic re-guard banner.
+		expect(screen.queryByTestId("rollback-rejected")).toBeNull();
+	});
+
+	it("singularises the change copy when exactly one field would change", () => {
+		renderHistory("admin");
+		// Rolling back to v7 re-writes exactly one field vs the current config
+		// (api.webhook_url) — app.name + fee_rate already match current at v7.
+		selectVersion(7);
+		const modal = openRollback();
+		// Copy is split across <b>1</b> + text; match the singular "field will change".
+		expect(within(modal).getByText(/field will change from the current version/)).toBeTruthy();
+		expect(within(modal).queryByText(/fields will change/)).toBeNull();
+	});
+
+	it("explains the superadmin lock bypass in the re-guard warning for an admin", () => {
+		state.locks = { data: { locks: [{ fieldPath: "api.webhook_url" }] } };
+		renderHistory("admin");
+		selectVersion(5);
+		openRollback();
+		expect(screen.getByTestId("rollback-warning")).toHaveTextContent(
+			/a superadmin can bypass locks/i,
+		);
+	});
+});
+
+describe("TenantHistory — diff value types + removed fields", () => {
+	it("renders a removed field with an empty 'removed' new side", () => {
+		renderHistory();
+		selectVersion(6);
+		const row = screen.getByTestId("diff-settlement.window");
+		// Both the change-type tag and the empty new-side placeholder read "removed".
+		expect(within(row).getAllByText("removed").length).toBeGreaterThanOrEqual(2);
+		expect(within(screen.getByTestId("diff-settlement.window-old")).getByText("48h")).toBeTruthy();
+		expect(
+			within(screen.getByTestId("diff-settlement.window-new")).getByText("removed"),
+		).toBeInTheDocument();
+	});
+
+	it("skips the no-field rollback marker entry in the diff body", () => {
+		renderHistory();
+		selectVersion(5);
+		// v5 has a marker entry (no fieldPath) + the webhook_url change; only the
+		// real field change renders.
+		expect(screen.getByTestId("diff-api.webhook_url")).toBeInTheDocument();
+		expect(screen.getByTestId("diff-summary")).toHaveTextContent("1 field changed");
+	});
+});
+
+describe("TenantHistory — loading / error / empty states", () => {
+	it("renders a skeleton while tenant or versions are loading", () => {
+		state.tenant = { data: undefined as never, isLoading: true, error: null };
+		const { container } = renderHistory();
+		expect(screen.queryByTestId("tenant-history")).toBeNull();
+		// The skeleton has no testid; assert the steady-state screen is absent + something rendered.
+		expect(container.firstChild).not.toBeNull();
+	});
+
+	it("renders an error message when the tenant query fails", () => {
+		state.tenant = { data: undefined as never, isLoading: false, error: new Error("boom") };
+		renderHistory();
+		expect(screen.getByText(/Error: boom/)).toBeInTheDocument();
+	});
+
+	it("renders nothing once loaded but the tenant is missing", () => {
+		state.tenant = { data: { tenant: undefined } as never, isLoading: false, error: null };
+		const { container } = renderHistory();
+		expect(screen.queryByTestId("tenant-history")).toBeNull();
+		expect(container.firstChild).toBeNull();
+	});
+
+	it("shows the no-versions empty state when the history is empty", () => {
+		state.versions = { data: { versions: [] }, isLoading: false };
+		renderHistory();
+		expect(screen.getByText(/No versions yet/)).toBeInTheDocument();
+		expect(screen.queryByTestId("version-timeline")).toBeNull();
+	});
+
+	it("renders the no-versions state even when the current version is unknown", () => {
+		state.versions = { data: { versions: [] }, isLoading: false };
+		state.config = { data: { config: { version: undefined, values: [] } } };
+		renderHistory();
+		expect(screen.getByText(/No versions yet/)).toBeInTheDocument();
+	});
+});
+
+describe("TenantHistory — diff base + timestamps", () => {
+	it("labels the earliest version's diff base as the empty/initial set", () => {
+		renderHistory();
+		selectVersion(1); // earliest version → base is ∅ / initial
+		const pane = screen.getByTestId("diff-pane");
+		expect(within(pane).getByText("∅")).toBeInTheDocument();
+		expect(within(pane).getByText("initial")).toBeInTheDocument();
+	});
+
+	it("labels a mid-history version's diff base as the prior version", () => {
+		renderHistory();
+		selectVersion(7);
+		const pane = screen.getByTestId("diff-pane");
+		// base box shows v6, compare box shows v7.
+		expect(within(pane).getByText("v6")).toBeInTheDocument();
+		expect(within(pane).getByText("base")).toBeInTheDocument();
+	});
+
+	it("renders a formatted timestamp when the version carries createdAt", () => {
+		renderHistory();
+		// v8 has a createdAt; its formatted year should appear in its timeline item.
+		expect(within(screen.getByTestId("version-8")).getByText(/2026/)).toBeInTheDocument();
+	});
+
+	it("pluralises the re-guard warning list when multiple fields are blocked", () => {
+		// Rolling back to v3 re-writes app.name + payments.fee_rate vs current.
+		// Locking both yields two re-guard conflicts → plural "fields are".
+		state.locks = {
+			data: { locks: [{ fieldPath: "app.name" }, { fieldPath: "payments.fee_rate" }] },
+		};
+		renderHistory("admin");
+		selectVersion(3);
+		openRollback();
+		const warning = screen.getByTestId("rollback-warning");
+		expect(warning).toHaveTextContent(/fields are/i);
+		expect(within(warning).getByText("app.name")).toBeInTheDocument();
+		expect(within(warning).getByText("payments.fee_rate")).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Summary
- Rebuilds the version history + diff screen (hi-fi Screen 4) on the design tokens: a newest-first version timeline (with distinct create / rollback markers) beside a per-field diff of the selected version against its predecessor.
- The field diff is computed client-side from audit-log entries (the versions API returns version metadata only, no per-field deltas), producing ADDED / REMOVED / changed. Sensitive fields render `[REDACTED]` on both sides and can never reveal a value in a diff.
- Guarded rollback, offered only to config editors on a non-current version: `RollbackToVersion` re-guards every restored field server-side and rejects atomically (nothing written) when any is locked / read-only / write-once. The UI mirrors that guard chain client-side to warn first, and surfaces the atomic rejection (`FAILED_PRECONDITION`) as a distinct in-modal banner — separate from the config editor's concurrency-conflict (`ABORTED`) rebase.

## Test plan
- `npm run pre-commit` green (Biome, `tsc -b --noEmit`, vitest 270/270, vite build).
- New `diff.ts`, component, and `api-error` tests; codecov patch ≥ 80% on changed files (`diff.ts` / `api-error.ts` 100%, history screen 84.6% branch). E2E smoke unaffected (no history-route assertions).

Closes #92
