### PR TITLE
feat: schema authoring workbench

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { ToastProvider } from "./lib/toast";
 import { Home } from "./pages/Home";
 import { NotFound } from "./pages/NotFound";
 import { SystemOverview } from "./pages/SystemOverview";
+import { SchemaAuthor } from "./pages/schemas/SchemaAuthor";
 import { SchemaDetail } from "./pages/schemas/SchemaDetail";
 import { SchemaImport } from "./pages/schemas/SchemaImport";
 import { SchemaList } from "./pages/schemas/SchemaList";
@@ -79,6 +80,7 @@ export function App() {
 										<Route path="schemas" element={<SchemaList />} />
 										<Route path="schemas/import" element={<SchemaImport />} />
 										<Route path="schemas/:id" element={<SchemaDetail />} />
+										<Route path="schemas/:id/author" element={<SchemaAuthor />} />
 										<Route path="tenants" element={<TenantList />} />
 										<Route path="tenants/create" element={<TenantCreate />} />
 										<Route path="tenants/:id" element={<TenantConfig />} />

--- a/src/lib/__tests__/schema-authoring.test.ts
+++ b/src/lib/__tests__/schema-authoring.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from "vitest";
+import type { components } from "../../api/schema";
+import {
+	buildUpdateBody,
+	cleanConstraints,
+	constraintKind,
+	diffFields,
+	duplicatePaths,
+	FIELD_TYPE_ORDER,
+	FLAG_DEFS,
+	fieldChanged,
+	isDirty,
+	isRuleComplete,
+	newFieldDraft,
+	summarizeRule,
+	validateFieldDef,
+} from "../schema-authoring";
+
+type SchemaField = components["schemas"]["v1SchemaField"];
+
+const baseField = (over: Partial<SchemaField> = {}): SchemaField => ({
+	path: "a.b",
+	type: "FIELD_TYPE_STRING",
+	constraints: {},
+	...over,
+});
+
+describe("FIELD_TYPE_ORDER + FLAG_DEFS", () => {
+	it("lists all eight authorable types", () => {
+		expect(FIELD_TYPE_ORDER).toHaveLength(8);
+		expect(FIELD_TYPE_ORDER).toContain("FIELD_TYPE_INT");
+		expect(FIELD_TYPE_ORDER).toContain("FIELD_TYPE_JSON");
+		expect(FIELD_TYPE_ORDER).not.toContain("FIELD_TYPE_UNSPECIFIED");
+	});
+
+	it("exposes the five field flags with camelCase keys", () => {
+		const keys = FLAG_DEFS.map((f) => f.key);
+		expect(keys).toEqual(["nullable", "readOnly", "writeOnce", "sensitive", "deprecated"]);
+	});
+});
+
+describe("constraintKind", () => {
+	it("maps int/number to numeric", () => {
+		expect(constraintKind("FIELD_TYPE_INT")).toBe("numeric");
+		expect(constraintKind("FIELD_TYPE_NUMBER")).toBe("numeric");
+	});
+	it("maps string/duration/url/json to their kinds", () => {
+		expect(constraintKind("FIELD_TYPE_STRING")).toBe("string");
+		expect(constraintKind("FIELD_TYPE_DURATION")).toBe("duration");
+		expect(constraintKind("FIELD_TYPE_URL")).toBe("url");
+		expect(constraintKind("FIELD_TYPE_JSON")).toBe("json");
+	});
+	it("maps bool/time/undefined to none", () => {
+		expect(constraintKind("FIELD_TYPE_BOOL")).toBe("none");
+		expect(constraintKind("FIELD_TYPE_TIME")).toBe("none");
+		expect(constraintKind(undefined)).toBe("none");
+	});
+});
+
+describe("newFieldDraft", () => {
+	it("seeds a string field with a unique synthetic path", () => {
+		expect(newFieldDraft(3)).toEqual({
+			path: "new.field_3",
+			type: "FIELD_TYPE_STRING",
+			constraints: {},
+		});
+	});
+});
+
+describe("cleanConstraints", () => {
+	it("returns undefined for undefined or fully-empty constraints", () => {
+		expect(cleanConstraints(undefined)).toBeUndefined();
+		expect(cleanConstraints({})).toBeUndefined();
+		expect(cleanConstraints({ regex: "  ", jsonSchema: "" })).toBeUndefined();
+	});
+	it("keeps numeric zero and non-empty values, drops blanks", () => {
+		expect(cleanConstraints({ min: 0, max: 10, regex: "", enumValues: [] })).toEqual({
+			min: 0,
+			max: 10,
+		});
+	});
+	it("keeps a populated enum and json schema", () => {
+		expect(cleanConstraints({ enumValues: ["a"], jsonSchema: "{}" })).toEqual({
+			enumValues: ["a"],
+			jsonSchema: "{}",
+		});
+	});
+	it("keeps exclusive bounds and length bounds", () => {
+		expect(
+			cleanConstraints({ exclusiveMin: 1, exclusiveMax: 9, minLength: 2, maxLength: 5 }),
+		).toEqual({ exclusiveMin: 1, exclusiveMax: 9, minLength: 2, maxLength: 5 });
+	});
+});
+
+describe("fieldChanged", () => {
+	it("treats a field with no baseline as changed (added)", () => {
+		expect(fieldChanged(baseField(), undefined)).toBe(true);
+	});
+	it("is false for an identical field (ignoring empty constraints)", () => {
+		expect(fieldChanged(baseField(), baseField())).toBe(false);
+	});
+	it("detects a title change", () => {
+		expect(fieldChanged(baseField({ title: "X" }), baseField())).toBe(true);
+	});
+	it("detects a constraint change", () => {
+		expect(
+			fieldChanged(baseField({ constraints: { min: 1 } }), baseField({ constraints: {} })),
+		).toBe(true);
+	});
+	it("ignores cosmetic empty-string vs missing differences", () => {
+		expect(fieldChanged(baseField({ description: "" }), baseField())).toBe(false);
+	});
+});
+
+describe("diffFields + isDirty", () => {
+	const baseline: SchemaField[] = [
+		baseField({ path: "a", title: "A" }),
+		baseField({ path: "b", title: "B" }),
+	];
+
+	it("reports no diff for an identical draft", () => {
+		const diff = diffFields(baseline, baseline);
+		expect(diff).toEqual({ added: [], modified: [], removed: [] });
+		expect(isDirty(diff)).toBe(false);
+	});
+
+	it("detects added, modified, and removed fields together", () => {
+		const draft: SchemaField[] = [
+			baseField({ path: "a", title: "A2" }), // modified
+			baseField({ path: "c", title: "C" }), // added
+		];
+		const diff = diffFields(draft, baseline);
+		expect(diff.added).toEqual(["c"]);
+		expect(diff.modified).toEqual(["a"]);
+		expect(diff.removed).toEqual(["b"]);
+		expect(isDirty(diff)).toBe(true);
+	});
+});
+
+describe("buildUpdateBody", () => {
+	const baseline: SchemaField[] = [
+		baseField({ path: "a", title: "A" }),
+		baseField({ path: "b", title: "B" }),
+	];
+
+	it("sends only the changed + added fields and removed paths", () => {
+		const draft: SchemaField[] = [
+			baseField({ path: "a", title: "A2" }), // modified
+			baseField({ path: "c", title: "C" }), // added
+		];
+		const body = buildUpdateBody(draft, baseline, "note");
+		expect(body.versionDescription).toBe("note");
+		expect(body.removeFields).toEqual(["b"]);
+		const paths = (body.fields ?? []).map((f) => f.path).sort();
+		expect(paths).toEqual(["a", "c"]);
+	});
+
+	it("omits empty fields / removeFields / versionDescription", () => {
+		const body = buildUpdateBody(baseline, baseline, "   ");
+		expect(body.fields).toBeUndefined();
+		expect(body.removeFields).toBeUndefined();
+		expect(body.versionDescription).toBeUndefined();
+	});
+
+	it("strips no-op constraints from the outgoing fields", () => {
+		const draft: SchemaField[] = [
+			baseField({ path: "a", title: "A", constraints: { min: 1, regex: "" } }),
+			baseField({ path: "b", title: "B" }),
+		];
+		const body = buildUpdateBody(draft, baseline, "");
+		expect(body.fields?.[0].constraints).toEqual({ min: 1 });
+	});
+});
+
+describe("validateFieldDef", () => {
+	it("rejects an empty path", () => {
+		expect(validateFieldDef(baseField({ path: "" }))).toMatch(/Path is required/);
+	});
+	it("rejects a malformed path", () => {
+		expect(validateFieldDef(baseField({ path: "bad path!" }))).toMatch(/dotted segments/);
+	});
+	it("accepts a well-formed dotted path", () => {
+		expect(validateFieldDef(baseField({ path: "a.b_c.d2" }))).toBeNull();
+	});
+	it("rejects an uncompilable regex", () => {
+		expect(validateFieldDef(baseField({ constraints: { regex: "(" } }))).toMatch(
+			/valid regular expression/,
+		);
+	});
+	it("rejects invalid JSON schema on a json field", () => {
+		expect(
+			validateFieldDef(
+				baseField({ type: "FIELD_TYPE_JSON", constraints: { jsonSchema: "{ broken" } }),
+			),
+		).toMatch(/valid JSON/);
+	});
+	it("rejects negative and inverted length bounds", () => {
+		expect(validateFieldDef(baseField({ constraints: { minLength: -1 } }))).toMatch(
+			/cannot be negative/,
+		);
+		expect(validateFieldDef(baseField({ constraints: { minLength: 5, maxLength: 2 } }))).toMatch(
+			/exceed maximum length/,
+		);
+	});
+	it("rejects inverted min/max", () => {
+		expect(validateFieldDef(baseField({ constraints: { min: 10, max: 1 } }))).toMatch(
+			/cannot exceed maximum/,
+		);
+	});
+});
+
+describe("duplicatePaths", () => {
+	it("returns the set of colliding paths, ignoring blanks", () => {
+		const dupes = duplicatePaths([
+			baseField({ path: "a" }),
+			baseField({ path: "a" }),
+			baseField({ path: "" }),
+			baseField({ path: "b" }),
+		]);
+		expect([...dupes]).toEqual(["a"]);
+	});
+});
+
+describe("dependent rules helpers", () => {
+	it("isRuleComplete requires both sides non-empty", () => {
+		expect(isRuleComplete({ when: [], require: [] })).toBe(false);
+		expect(isRuleComplete({ when: ["a"], require: [] })).toBe(false);
+		expect(isRuleComplete({ when: ["a"], require: ["b"] })).toBe(true);
+	});
+	it("summarizeRule renders a complete rule and flags an incomplete one", () => {
+		expect(summarizeRule({ when: ["a", "b"], require: ["c"] })).toBe(
+			"require c when a + b present",
+		);
+		expect(summarizeRule({ when: [], require: ["c"] })).toBe("incomplete rule");
+	});
+});

--- a/src/lib/schema-authoring.ts
+++ b/src/lib/schema-authoring.ts
@@ -1,0 +1,280 @@
+/**
+ * Pure helpers for the schema-authoring workbench (hi-fi Screen 5).
+ *
+ * The workbench is superadmin-only structured editing of field *definitions* —
+ * deliberately separate from the config editor, which is value entry against a
+ * published schema. These helpers stay free of React/DOM so the draft model,
+ * the diff against the server, and the UpdateSchema request body are all
+ * directly unit-testable (the backbone of the lifecycle wiring).
+ */
+
+import type { components } from "../api/schema";
+
+type FieldType = components["schemas"]["v1FieldType"];
+type FieldConstraints = components["schemas"]["v1FieldConstraints"];
+type SchemaField = components["schemas"]["v1SchemaField"];
+type UpdateSchemaBody = components["schemas"]["SchemaServiceUpdateSchemaBody"];
+
+/** The eight authorable field types, in display order, with a short type token. */
+export const FIELD_TYPE_ORDER: FieldType[] = [
+	"FIELD_TYPE_INT",
+	"FIELD_TYPE_NUMBER",
+	"FIELD_TYPE_STRING",
+	"FIELD_TYPE_BOOL",
+	"FIELD_TYPE_TIME",
+	"FIELD_TYPE_DURATION",
+	"FIELD_TYPE_URL",
+	"FIELD_TYPE_JSON",
+];
+
+/** A per-field boolean flag the editor exposes as a toggle, with copy. */
+export interface FlagDef {
+	/** Key on the SchemaField (camelCase, as the generated API uses). */
+	key: "nullable" | "readOnly" | "writeOnce" | "sensitive" | "deprecated";
+	label: string;
+	hint: string;
+}
+
+/**
+ * The flag grid. These flags drive every field *state* the config editor renders
+ * (read-only / write-once / sensitive / deprecated / nullable), so they live here
+ * at the point of authoring.
+ */
+export const FLAG_DEFS: FlagDef[] = [
+	{ key: "nullable", label: "Nullable", hint: "May be left empty/null; falls back to default." },
+	{ key: "readOnly", label: "Read-only", hint: "System-managed — never editable in the UI." },
+	{
+		key: "writeOnce",
+		label: "Write-once",
+		hint: "Settable once, then permanently immutable.",
+	},
+	{
+		key: "sensitive",
+		label: "Sensitive",
+		hint: "Write-only — server redacts to [REDACTED] on every read.",
+	},
+	{
+		key: "deprecated",
+		label: "Deprecated",
+		hint: "Flagged for removal; prefer a replacement field.",
+	},
+];
+
+/** Which constraint inputs a given field type exposes. Drives the adaptive editor. */
+export type ConstraintKind = "numeric" | "string" | "duration" | "url" | "json" | "none";
+
+/** Map a field type to its constraint editor kind. */
+export function constraintKind(type: FieldType | undefined): ConstraintKind {
+	switch (type) {
+		case "FIELD_TYPE_INT":
+		case "FIELD_TYPE_NUMBER":
+			return "numeric";
+		case "FIELD_TYPE_STRING":
+			return "string";
+		case "FIELD_TYPE_DURATION":
+			return "duration";
+		case "FIELD_TYPE_URL":
+			return "url";
+		case "FIELD_TYPE_JSON":
+			return "json";
+		default:
+			// bool, time, unspecified take no structural constraints in this editor.
+			return "none";
+	}
+}
+
+/**
+ * A draft field path that doesn't yet exist on the server, created when the user
+ * adds a brand-new field. The synthetic seed keeps it editable until the user
+ * gives it a real dotted path.
+ */
+export function newFieldDraft(index: number): SchemaField {
+	return {
+		path: `new.field_${index}`,
+		type: "FIELD_TYPE_STRING",
+		constraints: {},
+	};
+}
+
+/**
+ * Trim empty/blank constraint entries so the diff and the request body don't
+ * carry no-op keys (e.g. an empty regex, an empty enum). Numeric zero is kept.
+ */
+export function cleanConstraints(c: FieldConstraints | undefined): FieldConstraints | undefined {
+	if (!c) return undefined;
+	const out: FieldConstraints = {};
+	if (c.min !== undefined) out.min = c.min;
+	if (c.max !== undefined) out.max = c.max;
+	if (c.exclusiveMin !== undefined) out.exclusiveMin = c.exclusiveMin;
+	if (c.exclusiveMax !== undefined) out.exclusiveMax = c.exclusiveMax;
+	if (c.minLength !== undefined) out.minLength = c.minLength;
+	if (c.maxLength !== undefined) out.maxLength = c.maxLength;
+	if (c.regex && c.regex.trim() !== "") out.regex = c.regex;
+	if (c.jsonSchema && c.jsonSchema.trim() !== "") out.jsonSchema = c.jsonSchema;
+	if (c.enumValues && c.enumValues.length > 0) out.enumValues = c.enumValues;
+	return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/** Stable JSON of a field for change-detection — key order normalized. */
+function canonical(field: SchemaField): string {
+	const f: SchemaField = {
+		...field,
+		constraints: cleanConstraints(field.constraints),
+	};
+	// Drop undefined/empty so cosmetic differences don't read as changes.
+	const entries = Object.entries(f)
+		.filter(([, v]) => v !== undefined && v !== "" && v !== false)
+		.sort(([a], [b]) => a.localeCompare(b));
+	return JSON.stringify(entries, (_k, v) => v);
+}
+
+/** Whether a field's definition differs from its server baseline. */
+export function fieldChanged(draft: SchemaField, baseline: SchemaField | undefined): boolean {
+	if (!baseline) return true;
+	return canonical(draft) !== canonical(baseline);
+}
+
+/** A summary of how a draft diverges from the published/latest baseline fields. */
+export interface SchemaDiff {
+	/** Paths present in the draft but not the baseline. */
+	added: string[];
+	/** Paths whose definition changed. */
+	modified: string[];
+	/** Paths present in the baseline but removed from the draft. */
+	removed: string[];
+}
+
+/** Compute the add / modify / remove diff between a draft and the baseline. */
+export function diffFields(draft: SchemaField[], baseline: SchemaField[]): SchemaDiff {
+	const baseByPath = new Map<string, SchemaField>();
+	for (const f of baseline) if (f.path) baseByPath.set(f.path, f);
+	const draftPaths = new Set<string>();
+
+	const added: string[] = [];
+	const modified: string[] = [];
+	for (const f of draft) {
+		const path = f.path ?? "";
+		draftPaths.add(path);
+		const base = baseByPath.get(path);
+		if (!base) added.push(path);
+		else if (fieldChanged(f, base)) modified.push(path);
+	}
+	const removed: string[] = [];
+	for (const path of baseByPath.keys()) {
+		if (!draftPaths.has(path)) removed.push(path);
+	}
+	return { added, modified, removed };
+}
+
+/** Whether the draft has any pending change versus the baseline. */
+export function isDirty(diff: SchemaDiff): boolean {
+	return diff.added.length + diff.modified.length + diff.removed.length > 0;
+}
+
+/**
+ * Build the UpdateSchema (PATCH /v1/schemas/{id}) request body from a draft.
+ *
+ * UpdateSchema has merge semantics: `fields` lists fields to add or modify and
+ * `removeFields` lists paths to drop; everything not mentioned is carried forward
+ * unchanged from the latest version. The server creates a NEW draft version from
+ * the latest — it never edits a published version in place. So we send only the
+ * delta (added + modified fields, removed paths), which keeps the request minimal
+ * and matches the server's carry-forward model.
+ */
+export function buildUpdateBody(
+	draft: SchemaField[],
+	baseline: SchemaField[],
+	versionDescription: string,
+): UpdateSchemaBody {
+	const diff = diffFields(draft, baseline);
+	const changedPaths = new Set([...diff.added, ...diff.modified]);
+	const fields = draft
+		.filter((f) => changedPaths.has(f.path ?? ""))
+		.map((f) => ({ ...f, constraints: cleanConstraints(f.constraints) }));
+
+	const body: UpdateSchemaBody = {};
+	if (fields.length > 0) body.fields = fields;
+	if (diff.removed.length > 0) body.removeFields = diff.removed;
+	if (versionDescription.trim() !== "") body.versionDescription = versionDescription.trim();
+	return body;
+}
+
+/**
+ * Validate a draft field's *definition* (not its value). Returns a human error or
+ * null. Guards the things that would make the schema unimportable: a missing or
+ * malformed path, a regex that can't compile, a JSON-schema constraint that isn't
+ * valid JSON, and a deprecated field with no redirect target.
+ */
+export function validateFieldDef(field: SchemaField): string | null {
+	const path = (field.path ?? "").trim();
+	if (path === "") return "Path is required.";
+	if (!/^[a-zA-Z0-9_]+(\.[a-zA-Z0-9_]+)*$/.test(path)) {
+		return "Path must be dotted segments of letters, digits, or underscores.";
+	}
+	const c = field.constraints ?? {};
+	if (c.regex && c.regex.trim() !== "") {
+		try {
+			new RegExp(c.regex);
+		} catch {
+			return "Pattern is not a valid regular expression.";
+		}
+	}
+	if (field.type === "FIELD_TYPE_JSON" && c.jsonSchema && c.jsonSchema.trim() !== "") {
+		try {
+			JSON.parse(c.jsonSchema);
+		} catch {
+			return "JSON Schema must be valid JSON.";
+		}
+	}
+	if (
+		(c.minLength !== undefined && c.minLength < 0) ||
+		(c.maxLength !== undefined && c.maxLength < 0)
+	) {
+		return "Length bounds cannot be negative.";
+	}
+	if (c.minLength !== undefined && c.maxLength !== undefined && c.minLength > c.maxLength) {
+		return "Minimum length cannot exceed maximum length.";
+	}
+	if (c.min !== undefined && c.max !== undefined && c.min > c.max) {
+		return "Minimum cannot exceed maximum.";
+	}
+	return null;
+}
+
+/** Detect duplicate paths in a draft — returns the set of paths that collide. */
+export function duplicatePaths(fields: SchemaField[]): Set<string> {
+	const seen = new Set<string>();
+	const dupes = new Set<string>();
+	for (const f of fields) {
+		const p = (f.path ?? "").trim();
+		if (p === "") continue;
+		if (seen.has(p)) dupes.add(p);
+		seen.add(p);
+	}
+	return dupes;
+}
+
+/**
+ * A single dependent_required rule: when every `when` field is present, every
+ * `require` field becomes required. The decree gateway does not yet expose a
+ * dependent_required model on the schema (no field on v1Schema / v1SchemaField),
+ * so these are authored and validated client-side only — see SchemaAuthor for the
+ * graceful-degradation note. Kept as a pure shape so the builder is testable.
+ */
+export interface DependentRule {
+	/** Fields that must be present to trigger the requirement. */
+	when: string[];
+	/** Fields that become required when the trigger holds. */
+	require: string[];
+}
+
+/** Whether a dependent rule is complete enough to keep (both sides non-empty). */
+export function isRuleComplete(rule: DependentRule): boolean {
+	return rule.when.length > 0 && rule.require.length > 0;
+}
+
+/** A human one-line summary of a dependent rule for display. */
+export function summarizeRule(rule: DependentRule): string {
+	if (!isRuleComplete(rule)) return "incomplete rule";
+	return `require ${rule.require.join(", ")} when ${rule.when.join(" + ")} present`;
+}

--- a/src/pages/schemas/SchemaAuthor.tsx
+++ b/src/pages/schemas/SchemaAuthor.tsx
@@ -1,0 +1,1472 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useId, useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import type { components } from "../../api/schema";
+import { SkeletonDetail } from "../../components/Skeleton";
+import { formatError } from "../../lib/api-error";
+import { useAuth } from "../../lib/auth";
+import { fieldTypeIcon, fieldTypeLabel } from "../../lib/field-types";
+import { groupFields } from "../../lib/fields";
+import { useApiClient, useSchema } from "../../lib/hooks";
+import { canManageSchemas } from "../../lib/permissions";
+import {
+	buildUpdateBody,
+	constraintKind,
+	type DependentRule,
+	diffFields,
+	duplicatePaths,
+	FIELD_TYPE_ORDER,
+	FLAG_DEFS,
+	isDirty,
+	isRuleComplete,
+	newFieldDraft,
+	summarizeRule,
+	validateFieldDef,
+} from "../../lib/schema-authoring";
+import { useToast } from "../../lib/toast";
+
+type SchemaField = components["schemas"]["v1SchemaField"];
+type FieldConstraints = components["schemas"]["v1FieldConstraints"];
+type FieldType = components["schemas"]["v1FieldType"];
+
+const RULES_KEY = "@rules";
+
+/**
+ * Route wrapper: gate the schema-authoring workbench to superadmin. Defining
+ * typed fields/constraints is a global, platform-level capability, so this screen
+ * does not exist for admin/user (who enter *values* against a published schema,
+ * never author one). A non-superadmin who reaches the URL gets a clear refusal,
+ * not a disabled editor. Keeping the gate in a wrapper keeps the inner workbench's
+ * hook order stable (no role-conditional hooks).
+ */
+export function SchemaAuthor() {
+	const { auth } = useAuth();
+	if (!canManageSchemas(auth.role)) {
+		return (
+			<div data-testid="schema-author-denied" className="mx-auto max-w-lg py-16 text-center">
+				<h2 className="text-lg font-semibold text-fg">Not available</h2>
+				<p className="mt-2 text-sm text-fg-2">
+					Authoring schema definitions is a superadmin-only, platform-level capability.
+				</p>
+				<Link to="/schemas" className="mt-4 inline-block text-sm text-accent hover:underline">
+					&larr; Back to schemas
+				</Link>
+			</div>
+		);
+	}
+	return <SchemaWorkbench />;
+}
+
+/** The authoring workbench itself — only mounted for superadmin. */
+function SchemaWorkbench() {
+	const { id } = useParams<{ id: string }>();
+	const schemaId = id ?? "";
+	const { data, isLoading, error } = useSchema(schemaId);
+	const client = useApiClient();
+	const queryClient = useQueryClient();
+	const { toast } = useToast();
+
+	const schema = data?.schema;
+	const published = schema?.published ?? false;
+	const version = schema?.version ?? 1;
+
+	// The server's latest version is the baseline the draft is diffed against.
+	const baseline = useMemo<SchemaField[]>(() => schema?.fields ?? [], [schema]);
+
+	// Local working copy of the field definitions. Seeded from the server once
+	// loaded; edits stay client-side until Save draft round-trips via UpdateSchema.
+	const [draft, setDraft] = useState<SchemaField[] | null>(null);
+	const fields = draft ?? baseline;
+
+	// Seed the draft the first time the schema arrives (or after a reset).
+	if (draft === null && schema) {
+		setDraft(baseline.map((f) => ({ ...f, constraints: { ...(f.constraints ?? {}) } })));
+	}
+
+	const [selected, setSelected] = useState<string>("");
+	const [versionNote, setVersionNote] = useState("");
+	const [newFieldSeq, setNewFieldSeq] = useState(1);
+	const [showPublish, setShowPublish] = useState(false);
+	// dependent_required rules — authored client-side only (see degradation note).
+	const [rules, setRules] = useState<DependentRule[]>([]);
+
+	const diff = useMemo(() => diffFields(fields, baseline), [fields, baseline]);
+	const dirty = isDirty(diff);
+	const dupes = useMemo(() => duplicatePaths(fields), [fields]);
+
+	const errorByPath = useMemo(() => {
+		const m = new Map<string, string>();
+		for (const f of fields) {
+			const p = f.path ?? "";
+			if (dupes.has(p.trim())) m.set(p, "Duplicate path — each field path must be unique.");
+			const err = validateFieldDef(f);
+			if (err && !m.has(p)) m.set(p, err);
+		}
+		return m;
+	}, [fields, dupes]);
+
+	const hasErrors = errorByPath.size > 0;
+
+	const updateField = useCallback((path: string, patch: Partial<SchemaField>) => {
+		setDraft((prev) => (prev ?? []).map((f) => (f.path === path ? { ...f, ...patch } : f)));
+		// Editing the path renames the field's identity; keep the selection on it so
+		// the editor (and its error panel, keyed on the selected path) stays open.
+		if (patch.path !== undefined && patch.path !== path) {
+			setSelected((cur) => (cur === path ? (patch.path ?? cur) : cur));
+		}
+	}, []);
+
+	const updateConstraints = useCallback((path: string, patch: Partial<FieldConstraints>) => {
+		setDraft((prev) =>
+			(prev ?? []).map((f) =>
+				f.path === path ? { ...f, constraints: { ...(f.constraints ?? {}), ...patch } } : f,
+			),
+		);
+	}, []);
+
+	const addField = useCallback(() => {
+		const f = newFieldDraft(newFieldSeq);
+		setNewFieldSeq((n) => n + 1);
+		setDraft((prev) => [...(prev ?? []), f]);
+		setSelected(f.path ?? "");
+	}, [newFieldSeq]);
+
+	const deleteField = useCallback((path: string) => {
+		setDraft((prev) => (prev ?? []).filter((f) => f.path !== path));
+		setSelected((cur) => (cur === path ? "" : cur));
+	}, []);
+
+	const resetDraft = useCallback(() => {
+		setDraft(baseline.map((f) => ({ ...f, constraints: { ...(f.constraints ?? {}) } })));
+		setVersionNote("");
+		setSelected("");
+	}, [baseline]);
+
+	// Save draft = UpdateSchema (PATCH). The server creates a NEW draft version
+	// from the latest; it never edits a published version in place.
+	const saveMutation = useMutation({
+		mutationFn: async () => {
+			const body = buildUpdateBody(fields, baseline, versionNote);
+			const { data: res, error: err } = await client.PATCH("/v1/schemas/{id}", {
+				params: { path: { id: schemaId } },
+				body,
+			});
+			if (err) throw err;
+			return res;
+		},
+		onSuccess: (res) => {
+			const v = res?.schema?.version;
+			toast.success(v ? `Saved — draft v${v} created` : "Saved draft");
+			setDraft(null); // re-seed from the refreshed server baseline
+			setVersionNote("");
+			queryClient.invalidateQueries({ queryKey: ["schemas", schemaId] });
+			queryClient.invalidateQueries({ queryKey: ["schemas"] });
+		},
+		onError: (err: unknown) => toast.error(`Save failed: ${formatError(err)}`),
+	});
+
+	// Publish = PublishSchema. Freezes the version permanently; does NOT rebind
+	// any tenant — existing tenants stay on their bound version until migrated.
+	const publishMutation = useMutation({
+		mutationFn: async () => {
+			const { error: err } = await client.POST("/v1/schemas/{id}/publish", {
+				params: { path: { id: schemaId } },
+				body: { version },
+			});
+			if (err) throw err;
+		},
+		onSuccess: () => {
+			setShowPublish(false);
+			toast.success(`Published v${version} — now immutable`);
+			queryClient.invalidateQueries({ queryKey: ["schemas", schemaId] });
+			queryClient.invalidateQueries({ queryKey: ["schemas"] });
+		},
+		onError: (err: unknown) => {
+			setShowPublish(false);
+			toast.error(`Publish failed: ${formatError(err)}`);
+		},
+	});
+
+	// Fork a published version into a new draft: an empty-delta UpdateSchema spawns
+	// the next version (carry-forward), which lands as an editable draft.
+	const forkMutation = useMutation({
+		mutationFn: async () => {
+			const { data: res, error: err } = await client.PATCH("/v1/schemas/{id}", {
+				params: { path: { id: schemaId } },
+				body: { versionDescription: `Draft from v${version}` },
+			});
+			if (err) throw err;
+			return res;
+		},
+		onSuccess: (res) => {
+			toast.success(`New draft v${res?.schema?.version ?? version + 1} created`);
+			setDraft(null);
+			queryClient.invalidateQueries({ queryKey: ["schemas", schemaId] });
+			queryClient.invalidateQueries({ queryKey: ["schemas"] });
+		},
+		onError: (err: unknown) => toast.error(`Could not fork: ${formatError(err)}`),
+	});
+
+	if (isLoading) return <SkeletonDetail />;
+	if (error) {
+		return (
+			<p className="text-danger" data-testid="schema-author-error">
+				Error loading schema: {error.message}
+			</p>
+		);
+	}
+	if (!schema) return null;
+
+	const typeCount = new Set(fields.map((f) => f.type)).size;
+	const selectedField = fields.find((f) => f.path === selected) ?? null;
+
+	return (
+		<div data-testid="schema-author-page" className="min-w-0">
+			{/* Topbar: breadcrumb + lifecycle actions */}
+			<div className="mb-4 flex flex-wrap items-center gap-3">
+				<div className="min-w-0">
+					<Link to={`/schemas/${schemaId}`} className="text-xs text-accent hover:underline">
+						&larr; Back to {schema.name}
+					</Link>
+					<h1 className="mt-1 text-lg font-semibold text-fg">
+						Schema authoring{" "}
+						<span className="font-mono text-sm font-normal text-fg-3">{schema.name}</span>
+					</h1>
+				</div>
+
+				<span className="flex-1" />
+
+				{dirty && !published && (
+					<span className="font-mono text-[11px] text-warn" data-testid="dirty-note">
+						● unsaved
+					</span>
+				)}
+				{!published && (
+					<button
+						type="button"
+						onClick={() => saveMutation.mutate()}
+						disabled={!dirty || hasErrors || saveMutation.isPending}
+						className="inline-flex items-center gap-1.5 rounded-[var(--r-sm)] border border-line-2 bg-surface-2 px-3 py-1.5 text-sm font-medium text-fg hover:bg-surface-3 disabled:cursor-not-allowed disabled:opacity-50"
+					>
+						<svg
+							aria-hidden="true"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							className="h-3.5 w-3.5"
+						>
+							<path d="M5 12l5 5L20 7" />
+						</svg>
+						{saveMutation.isPending ? "Saving…" : "Save draft"}
+					</button>
+				)}
+				{!published && (
+					<button
+						type="button"
+						onClick={() => setShowPublish(true)}
+						disabled={dirty || hasErrors}
+						title={dirty ? "Save the draft before publishing" : undefined}
+						className="inline-flex items-center gap-1.5 rounded-[var(--r-sm)] bg-ok px-3 py-1.5 text-sm font-semibold text-white hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
+					>
+						<svg
+							aria-hidden="true"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							className="h-3.5 w-3.5"
+						>
+							<path d="M12 19V5M5 12l7-7 7 7" />
+						</svg>
+						Publish v{version}
+					</button>
+				)}
+				{published && (
+					<button
+						type="button"
+						onClick={() => forkMutation.mutate()}
+						disabled={forkMutation.isPending}
+						className="inline-flex items-center gap-1.5 rounded-[var(--r-sm)] bg-accent px-3 py-1.5 text-sm font-semibold text-accent-fg hover:brightness-110 disabled:opacity-50"
+						data-testid="fork-btn"
+					>
+						<svg
+							aria-hidden="true"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							className="h-3.5 w-3.5"
+						>
+							<path d="M6 3v12M18 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM6 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM15 6a9 9 0 0 1-9 9" />
+						</svg>
+						{forkMutation.isPending ? "Forking…" : "New draft"}
+					</button>
+				)}
+			</div>
+
+			{/* Lifecycle bar */}
+			<LifecycleBar
+				schema={schema}
+				diff={diff}
+				dirty={dirty}
+				onReset={dirty ? resetDraft : undefined}
+			/>
+
+			<div className="mt-4 grid min-w-0 grid-cols-1 gap-4 lg:grid-cols-[minmax(0,17rem)_minmax(0,1fr)]">
+				{/* Field list */}
+				<aside className="min-w-0 rounded-[var(--r-md)] border border-line bg-surface">
+					<div className="flex items-center justify-between border-b border-line px-3 py-2.5">
+						<h2 className="text-sm font-semibold text-fg">Fields</h2>
+						<span className="font-mono text-[11px] text-fg-3" data-testid="field-count">
+							{fields.length} · {typeCount} type{typeCount === 1 ? "" : "s"}
+						</span>
+					</div>
+					{!published && (
+						<div className="border-b border-line px-3 py-2">
+							<button
+								type="button"
+								onClick={addField}
+								className="inline-flex w-full items-center justify-center gap-1.5 rounded-[var(--r-sm)] border border-dashed border-line-2 px-3 py-1.5 text-xs font-medium text-fg-2 hover:bg-surface-2 hover:text-fg"
+								data-testid="add-field"
+							>
+								<svg
+									aria-hidden="true"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="2"
+									className="h-3.5 w-3.5"
+								>
+									<path d="M12 5v14M5 12h14" />
+								</svg>
+								Add field
+							</button>
+						</div>
+					)}
+					<FieldList
+						fields={fields}
+						selected={selected}
+						errorByPath={errorByPath}
+						onSelect={setSelected}
+					/>
+				</aside>
+
+				{/* Editor */}
+				<section className="min-w-0">
+					{published && <ImmutableBanner version={version} onFork={() => forkMutation.mutate()} />}
+
+					{selected === RULES_KEY ? (
+						<DependentRulesEditor
+							fields={fields}
+							rules={rules}
+							readOnly={published}
+							onChange={setRules}
+						/>
+					) : selectedField ? (
+						<FieldEditor
+							key={selected}
+							field={selectedField}
+							readOnly={published}
+							error={errorByPath.get(selected)}
+							onChangeField={(patch) => updateField(selected, patch)}
+							onChangeConstraints={(patch) => updateConstraints(selected, patch)}
+							onDelete={() => deleteField(selected)}
+						/>
+					) : (
+						<EmptyEditor onAdd={published ? undefined : addField} />
+					)}
+				</section>
+			</div>
+
+			{showPublish && (
+				<PublishModal
+					name={schema.name ?? "schema"}
+					version={version}
+					pending={publishMutation.isPending}
+					onCancel={() => setShowPublish(false)}
+					onConfirm={(note) => {
+						setVersionNote(note);
+						publishMutation.mutate();
+					}}
+				/>
+			)}
+		</div>
+	);
+}
+
+// --- Lifecycle bar -----------------------------------------------------------
+
+function LifecycleBar({
+	schema,
+	diff,
+	dirty,
+	onReset,
+}: {
+	schema: components["schemas"]["v1Schema"];
+	diff: ReturnType<typeof diffFields>;
+	dirty: boolean;
+	onReset?: () => void;
+}) {
+	const published = schema.published ?? false;
+	const version = schema.version ?? 1;
+	return (
+		<div className="flex flex-wrap items-center gap-3 rounded-[var(--r-md)] border border-line bg-surface-2 px-3 py-2.5">
+			<span className="rounded-[var(--r-pill)] border border-line-2 bg-surface-3 px-2 py-0.5 font-mono text-[11px] text-fg-2">
+				{schema.name}
+			</span>
+			<span
+				className={`inline-flex items-center gap-1.5 rounded-[var(--r-pill)] px-2.5 py-0.5 font-mono text-[11px] ${
+					published
+						? "bg-ok-soft text-ok"
+						: "border border-dashed border-accent-line bg-accent-soft text-accent"
+				}`}
+				data-testid="lifecycle-state"
+			>
+				v{version} · {published ? "published" : "draft"}
+			</span>
+			{schema.parentVersion !== undefined && (
+				<span className="font-mono text-[11px] text-fg-3">forked from v{schema.parentVersion}</span>
+			)}
+
+			<span className="flex-1" />
+
+			{dirty && (
+				<span className="font-mono text-[11px] text-fg-3" data-testid="diff-summary">
+					+{diff.added.length} added · ~{diff.modified.length} changed · −{diff.removed.length}{" "}
+					removed
+				</span>
+			)}
+			{onReset && (
+				<button
+					type="button"
+					onClick={onReset}
+					className="rounded-[var(--r-xs)] px-2 py-0.5 font-mono text-[11px] text-accent hover:underline"
+				>
+					↺ discard changes
+				</button>
+			)}
+			<span
+				className={`inline-flex items-center gap-1.5 font-mono text-[11px] ${published ? "text-fg-2" : "text-fg-3"}`}
+			>
+				{published ? (
+					<>
+						<svg
+							aria-hidden="true"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							className="h-3 w-3"
+						>
+							<rect x="5" y="11" width="14" height="9" rx="2" />
+							<path d="M8 11V8a4 4 0 0 1 8 0v3" />
+						</svg>
+						immutable
+					</>
+				) : (
+					"editable"
+				)}
+			</span>
+		</div>
+	);
+}
+
+// --- Field list --------------------------------------------------------------
+
+const FLAG_DOT: Partial<Record<string, string>> = {
+	readOnly: "read-only",
+	writeOnce: "write-once",
+	sensitive: "sensitive",
+	deprecated: "deprecated",
+	nullable: "nullable",
+};
+
+function FieldList({
+	fields,
+	selected,
+	errorByPath,
+	onSelect,
+}: {
+	fields: SchemaField[];
+	selected: string;
+	errorByPath: Map<string, string>;
+	onSelect: (path: string) => void;
+}) {
+	const groups = useMemo(() => groupFields(fields), [fields]);
+	return (
+		<div className="max-h-[60vh] overflow-y-auto py-1">
+			{groups.map((group) => (
+				<div key={group.name || "general"}>
+					<div className="px-3 pt-2 pb-1 font-mono text-[9px] uppercase tracking-widest text-fg-3">
+						{group.name || "general"}
+					</div>
+					{group.fields.map((f) => {
+						const path = f.path ?? "";
+						const isSel = path === selected;
+						const invalid = errorByPath.has(path);
+						const flags = Object.entries(FLAG_DOT).filter(
+							([k]) => (f as Record<string, unknown>)[k],
+						);
+						return (
+							<button
+								type="button"
+								key={path}
+								onClick={() => onSelect(path)}
+								data-testid={`field-item-${path}`}
+								className={`flex w-full items-center gap-2 border-l-2 px-3 py-1.5 text-left ${
+									isSel ? "border-accent bg-accent-soft" : "border-transparent hover:bg-surface-2"
+								}`}
+							>
+								<span
+									title={fieldTypeLabel(f.type)}
+									className="flex h-5 w-7 flex-none items-center justify-center rounded-[var(--r-xs)] border border-line-2 bg-surface-2 font-mono text-[9px] text-fg-2"
+								>
+									{fieldTypeIcon(f.type)}
+								</span>
+								<span className="min-w-0 flex-1">
+									{f.title && <span className="block truncate text-[13px] text-fg">{f.title}</span>}
+									<span className="block truncate font-mono text-[10px] text-fg-3">{path}</span>
+								</span>
+								{invalid && (
+									<span
+										title="This field has an error"
+										className="h-1.5 w-1.5 flex-none rounded-full bg-danger"
+										data-testid={`field-error-dot-${path}`}
+									/>
+								)}
+								<span className="flex flex-none gap-0.5">
+									{flags.map(([k]) => (
+										<span key={k} title={k} className="h-1.5 w-1.5 rounded-full bg-fg-3" />
+									))}
+								</span>
+							</button>
+						);
+					})}
+				</div>
+			))}
+
+			{/* Cross-field rules entry */}
+			<button
+				type="button"
+				onClick={() => onSelect(RULES_KEY)}
+				data-testid="field-item-rules"
+				className={`mt-1 flex w-full items-center gap-2 border-t border-line border-l-2 px-3 py-2 text-left ${
+					selected === RULES_KEY
+						? "border-l-accent bg-accent-soft"
+						: "border-l-transparent hover:bg-surface-2"
+				}`}
+			>
+				<span className="flex h-5 w-7 flex-none items-center justify-center rounded-[var(--r-xs)] border border-line-2 bg-surface-2 font-mono text-[11px] text-fg-2">
+					⚿
+				</span>
+				<span className="min-w-0 flex-1">
+					<span className="block text-[13px] text-fg">Cross-field rules</span>
+					<span className="block font-mono text-[10px] text-fg-3">dependent_required</span>
+				</span>
+			</button>
+		</div>
+	);
+}
+
+// --- Immutable banner --------------------------------------------------------
+
+function ImmutableBanner({ version, onFork }: { version: number; onFork: () => void }) {
+	return (
+		<div
+			data-testid="immutable-banner"
+			className="mb-4 flex flex-wrap items-center gap-3 rounded-[var(--r-md)] border border-line-2 bg-surface-2 px-3 py-2.5"
+		>
+			<svg
+				aria-hidden="true"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="2"
+				className="h-4 w-4 flex-none text-fg-2"
+			>
+				<rect x="5" y="11" width="14" height="9" rx="2" />
+				<path d="M8 11V8a4 4 0 0 1 8 0v3" />
+			</svg>
+			<span className="min-w-0 flex-1 text-xs text-fg-2">
+				<b className="text-fg">v{version} is published — immutable.</b> Definitions can't be edited
+				in place; changes spawn a new draft version. Publishing does not rebind existing tenants.
+			</span>
+			<button
+				type="button"
+				onClick={onFork}
+				className="rounded-[var(--r-sm)] border border-line-2 bg-surface px-3 py-1 text-xs font-medium text-fg hover:bg-surface-3"
+			>
+				New draft
+			</button>
+		</div>
+	);
+}
+
+// --- Field editor ------------------------------------------------------------
+
+function FieldEditor({
+	field,
+	readOnly,
+	error,
+	onChangeField,
+	onChangeConstraints,
+	onDelete,
+}: {
+	field: SchemaField;
+	readOnly: boolean;
+	error: string | undefined;
+	onChangeField: (patch: Partial<SchemaField>) => void;
+	onChangeConstraints: (patch: Partial<FieldConstraints>) => void;
+	onDelete: () => void;
+}) {
+	return (
+		<div data-testid="field-editor" className="space-y-4">
+			{error && (
+				<p
+					role="alert"
+					data-testid="field-editor-error"
+					className="flex items-center gap-1.5 rounded-[var(--r-sm)] border border-danger bg-danger-soft px-3 py-2 text-xs text-danger"
+				>
+					<svg
+						aria-hidden="true"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						className="h-3.5 w-3.5 flex-none"
+					>
+						<circle cx="12" cy="12" r="9" />
+						<path d="M12 8v4m0 4h.01" />
+					</svg>
+					{error}
+				</p>
+			)}
+
+			{/* 1. Identity & type */}
+			<Section num={1} title="Identity & type">
+				<Row label="Title" sub="human label">
+					<input
+						aria-label="Title"
+						disabled={readOnly}
+						value={field.title ?? ""}
+						placeholder="e.g. Fee Rate"
+						onChange={(e) => onChangeField({ title: e.target.value })}
+						className={inputCls(readOnly)}
+					/>
+				</Row>
+				<Row label="Path" sub="dotted key">
+					<input
+						aria-label="Path"
+						disabled={readOnly}
+						value={field.path ?? ""}
+						placeholder="payments.fee_rate"
+						onChange={(e) => onChangeField({ path: e.target.value })}
+						className={`${inputCls(readOnly)} font-mono`}
+					/>
+				</Row>
+				<Row label="Type" sub="8 supported">
+					<TypePicker
+						value={field.type}
+						readOnly={readOnly}
+						onChange={(t) => onChangeField({ type: t, constraints: {} })}
+					/>
+				</Row>
+			</Section>
+
+			{/* 2. Constraints (type-adaptive) */}
+			<Section
+				num={2}
+				title="Constraints"
+				hint={`type-specific · ${fieldTypeLabel(field.type).toLowerCase()}`}
+			>
+				<ConstraintEditor field={field} readOnly={readOnly} onChange={onChangeConstraints} />
+			</Section>
+
+			{/* 3. Metadata */}
+			<Section num={3} title="Metadata">
+				<Row label="Description" sub="">
+					<textarea
+						aria-label="Description"
+						disabled={readOnly}
+						rows={2}
+						value={field.description ?? ""}
+						onChange={(e) => onChangeField({ description: e.target.value })}
+						className={`${inputCls(readOnly)} w-full`}
+					/>
+				</Row>
+				<Row label="Format" sub="hint, e.g. percentage / uri">
+					<input
+						aria-label="Format"
+						disabled={readOnly}
+						value={field.format ?? ""}
+						placeholder="none"
+						onChange={(e) => onChangeField({ format: e.target.value })}
+						className={`${inputCls(readOnly)} font-mono`}
+					/>
+				</Row>
+				<Row label="Example" sub="sample value">
+					<input
+						aria-label="Example"
+						disabled={readOnly}
+						value={field.example ?? ""}
+						onChange={(e) => onChangeField({ example: e.target.value })}
+						className={`${inputCls(readOnly)} font-mono`}
+					/>
+				</Row>
+				<Row label="Tags" sub="comma-separated grouping">
+					<input
+						aria-label="Tags"
+						disabled={readOnly}
+						value={(field.tags ?? []).join(", ")}
+						placeholder="payments, billing"
+						onChange={(e) =>
+							onChangeField({
+								tags: e.target.value
+									.split(",")
+									.map((t) => t.trim())
+									.filter((t) => t !== ""),
+							})
+						}
+						className={`${inputCls(readOnly)} font-mono`}
+					/>
+				</Row>
+				<Row label="Default" sub="used when unset">
+					<input
+						aria-label="Default"
+						disabled={readOnly}
+						value={field.defaultValue ?? ""}
+						placeholder="(no default)"
+						onChange={(e) => onChangeField({ defaultValue: e.target.value })}
+						className={`${inputCls(readOnly)} font-mono`}
+					/>
+				</Row>
+			</Section>
+
+			{/* 4. Flags */}
+			<Section num={4} title="Flags" hint="drive the field states in the config editor">
+				<FlagsGrid field={field} readOnly={readOnly} onChange={onChangeField} />
+			</Section>
+
+			{!readOnly && (
+				<div className="pt-1">
+					<button
+						type="button"
+						onClick={onDelete}
+						data-testid="delete-field"
+						className="inline-flex items-center gap-1.5 rounded-[var(--r-sm)] border border-[color-mix(in_oklch,var(--danger)_35%,transparent)] bg-danger-soft px-3 py-1.5 text-xs font-medium text-danger hover:brightness-105"
+					>
+						<svg
+							aria-hidden="true"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							className="h-3.5 w-3.5"
+						>
+							<path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />
+						</svg>
+						Delete field
+					</button>
+				</div>
+			)}
+		</div>
+	);
+}
+
+// --- Type picker -------------------------------------------------------------
+
+function TypePicker({
+	value,
+	readOnly,
+	onChange,
+}: {
+	value: FieldType | undefined;
+	readOnly: boolean;
+	onChange: (t: FieldType) => void;
+}) {
+	return (
+		<div className="flex flex-wrap gap-1.5">
+			{FIELD_TYPE_ORDER.map((t) => {
+				const on = t === value;
+				return (
+					<button
+						type="button"
+						key={t}
+						disabled={readOnly}
+						aria-pressed={on}
+						onClick={() => onChange(t)}
+						data-testid={`type-${t}`}
+						className={`inline-flex items-center gap-1.5 rounded-[var(--r-sm)] border px-2.5 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-60 ${
+							on
+								? "border-accent-line bg-accent-soft text-fg"
+								: "border-line-2 text-fg-2 hover:bg-surface-2"
+						}`}
+					>
+						<span className="font-mono text-[10px] text-fg-3">{fieldTypeIcon(t)}</span>
+						{fieldTypeLabel(t).toLowerCase()}
+					</button>
+				);
+			})}
+		</div>
+	);
+}
+
+// --- Constraint editor (adaptive) -------------------------------------------
+
+function ConstraintEditor({
+	field,
+	readOnly,
+	onChange,
+}: {
+	field: SchemaField;
+	readOnly: boolean;
+	onChange: (patch: Partial<FieldConstraints>) => void;
+}) {
+	const c = field.constraints ?? {};
+	const kind = constraintKind(field.type);
+
+	const numInput = (
+		key: "min" | "max" | "minLength" | "maxLength",
+		label: string,
+		placeholder: string,
+	) => (
+		<input
+			aria-label={label}
+			disabled={readOnly}
+			type="number"
+			value={c[key] ?? ""}
+			placeholder={placeholder}
+			onChange={(e) =>
+				onChange({ [key]: e.target.value === "" ? undefined : Number(e.target.value) })
+			}
+			className={`${inputCls(readOnly)} w-28 font-mono`}
+		/>
+	);
+
+	if (kind === "numeric") {
+		return (
+			<>
+				<Row label="Minimum" sub={field.type === "FIELD_TYPE_INT" ? "integer" : "float"}>
+					<div className="flex items-center gap-3">
+						{numInput("min", "Minimum", "—")}
+						<Toggle
+							label="exclusive"
+							checked={c.exclusiveMin !== undefined}
+							disabled={readOnly}
+							onChange={(on) => onChange({ exclusiveMin: on ? (c.min ?? 0) : undefined })}
+						/>
+					</div>
+				</Row>
+				<Row label="Maximum" sub="">
+					<div className="flex items-center gap-3">
+						{numInput("max", "Maximum", "—")}
+						<Toggle
+							label="exclusive"
+							checked={c.exclusiveMax !== undefined}
+							disabled={readOnly}
+							onChange={(on) => onChange({ exclusiveMax: on ? (c.max ?? 0) : undefined })}
+						/>
+					</div>
+				</Row>
+			</>
+		);
+	}
+
+	if (kind === "string") {
+		return (
+			<>
+				<Row label="Length" sub="min / max chars">
+					<div className="flex items-center gap-2">
+						{numInput("minLength", "Minimum length", "min")}
+						<span className="text-fg-3">–</span>
+						{numInput("maxLength", "Maximum length", "max")}
+					</div>
+				</Row>
+				<Row label="Pattern" sub="regex (RE2)">
+					<input
+						aria-label="Pattern"
+						disabled={readOnly}
+						value={c.regex ?? ""}
+						placeholder="^…$"
+						onChange={(e) => onChange({ regex: e.target.value })}
+						className={`${inputCls(readOnly)} w-full font-mono`}
+					/>
+				</Row>
+				<Row label="Enum" sub="allowed values">
+					<ChipSet
+						values={c.enumValues ?? []}
+						readOnly={readOnly}
+						placeholder="add value"
+						onChange={(vals) => onChange({ enumValues: vals.length > 0 ? vals : undefined })}
+						testid="enum-chips"
+					/>
+				</Row>
+			</>
+		);
+	}
+
+	if (kind === "duration") {
+		return (
+			<>
+				<Row label="Minimum" sub="seconds">
+					{numInput("min", "Minimum", "e.g. 3600")}
+				</Row>
+				<Row label="Maximum" sub="seconds">
+					{numInput("max", "Maximum", "e.g. 2592000")}
+				</Row>
+			</>
+		);
+	}
+
+	if (kind === "url") {
+		return (
+			<Row label="Enum" sub="restrict to specific URLs (optional)">
+				<ChipSet
+					values={c.enumValues ?? []}
+					readOnly={readOnly}
+					placeholder="https://…"
+					onChange={(vals) => onChange({ enumValues: vals.length > 0 ? vals : undefined })}
+					testid="url-enum-chips"
+				/>
+			</Row>
+		);
+	}
+
+	if (kind === "json") {
+		return (
+			<Row label="JSON Schema" sub="validates the value">
+				<textarea
+					aria-label="JSON Schema"
+					disabled={readOnly}
+					rows={6}
+					value={c.jsonSchema ?? ""}
+					placeholder='{ "type": "object" }'
+					onChange={(e) => onChange({ jsonSchema: e.target.value })}
+					className={`${inputCls(readOnly)} w-full font-mono text-xs`}
+				/>
+			</Row>
+		);
+	}
+
+	return (
+		<p className="text-xs text-fg-3" data-testid="no-constraints">
+			{field.type === "FIELD_TYPE_BOOL"
+				? "Booleans take no constraints."
+				: field.type === "FIELD_TYPE_TIME"
+					? "Times are validated as RFC 3339; no structural constraints."
+					: "This type takes no structural constraints."}
+		</p>
+	);
+}
+
+// --- Flags grid --------------------------------------------------------------
+
+function FlagsGrid({
+	field,
+	readOnly,
+	onChange,
+}: {
+	field: SchemaField;
+	readOnly: boolean;
+	onChange: (patch: Partial<SchemaField>) => void;
+}) {
+	return (
+		<div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+			{FLAG_DEFS.map((fd) => {
+				const on = !!(field as Record<string, unknown>)[fd.key];
+				return (
+					<div
+						key={fd.key}
+						data-testid={`flag-${fd.key}`}
+						className={`rounded-[var(--r-sm)] border p-2.5 ${
+							on ? "border-accent-line bg-accent-soft" : "border-line-2 bg-surface"
+						}`}
+					>
+						<div className="flex items-start justify-between gap-2">
+							<div className="min-w-0">
+								<div className="text-[13px] font-medium text-fg">{fd.label}</div>
+								<div className="mt-0.5 text-[11px] text-fg-3">{fd.hint}</div>
+							</div>
+							<Toggle
+								label={fd.label}
+								checked={on}
+								disabled={readOnly}
+								onChange={(checked) => {
+									if (fd.key === "deprecated" && !checked) {
+										onChange({ deprecated: false, redirectTo: undefined });
+									} else {
+										onChange({ [fd.key]: checked });
+									}
+								}}
+							/>
+						</div>
+						{fd.key === "deprecated" && on && (
+							<div className="mt-2">
+								<input
+									aria-label="Redirect to"
+									disabled={readOnly}
+									value={field.redirectTo ?? ""}
+									placeholder="path.to.replacement"
+									onChange={(e) => onChange({ redirectTo: e.target.value })}
+									className={`${inputCls(readOnly)} w-full font-mono`}
+								/>
+							</div>
+						)}
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
+// --- dependent_required rule builder ----------------------------------------
+
+/**
+ * Presence-triggered required-field rules (dependent_required): when every `when`
+ * field is set, the `require` fields become mandatory.
+ *
+ * GRACEFUL DEGRADATION: the decree REST gateway does not (yet) expose a
+ * dependent_required model — there is no such field on v1Schema or v1SchemaField,
+ * and UpdateSchema carries none. So rules authored here are held client-side and
+ * are NOT persisted; the banner says so plainly rather than implying a round-trip
+ * the gateway can't honour. When the server adds the field, wiring this to the
+ * UpdateSchema body is the only change needed.
+ */
+function DependentRulesEditor({
+	fields,
+	rules,
+	readOnly,
+	onChange,
+}: {
+	fields: SchemaField[];
+	rules: DependentRule[];
+	readOnly: boolean;
+	onChange: (rules: DependentRule[]) => void;
+}) {
+	const paths = fields.map((f) => f.path ?? "").filter((p) => p !== "");
+
+	const addRule = () => onChange([...rules, { when: [], require: [] }]);
+	const removeRule = (i: number) => onChange(rules.filter((_, idx) => idx !== i));
+	const setRule = (i: number, rule: DependentRule) =>
+		onChange(rules.map((r, idx) => (idx === i ? rule : r)));
+
+	return (
+		<div data-testid="dependent-rules" className="space-y-4">
+			<Section num="⚿" title="Cross-field rules — dependent_required" hint="presence-triggered">
+				<div
+					data-testid="dependent-required-note"
+					className="mb-3 flex items-start gap-2 rounded-[var(--r-sm)] border border-[color-mix(in_oklch,var(--warn)_35%,transparent)] bg-warn-soft px-3 py-2 text-[11px] text-warn"
+				>
+					<svg
+						aria-hidden="true"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						className="h-3.5 w-3.5 flex-none"
+					>
+						<path d="M12 9v4m0 4h.01M10.3 3.9 2.4 18a2 2 0 0 0 1.7 3h15.8a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z" />
+					</svg>
+					<span>
+						The config service gateway does not yet expose dependent_required on the schema, so
+						rules authored here are <b>not persisted</b>. This builder previews the intended model;
+						it will round-trip once the server adds the field.
+					</span>
+				</div>
+
+				{rules.length === 0 && (
+					<p className="text-xs text-fg-3" data-testid="rules-empty">
+						<b className="text-fg-2">No rules defined.</b> Add one to require a field only when
+						another is present.
+					</p>
+				)}
+
+				<div className="space-y-2">
+					{rules.map((rule, i) => (
+						<div
+							// biome-ignore lint/suspicious/noArrayIndexKey: rules are positional and order-stable
+							key={i}
+							data-testid={`rule-${i}`}
+							className="flex flex-wrap items-center gap-2 rounded-[var(--r-sm)] border border-line-2 bg-surface px-3 py-2"
+						>
+							<span className="font-mono text-[11px] text-fg-3">require</span>
+							<PathSelect
+								label={`Required field for rule ${i + 1}`}
+								paths={paths}
+								value={rule.require[0] ?? ""}
+								disabled={readOnly}
+								onChange={(p) => setRule(i, { ...rule, require: p ? [p] : [] })}
+							/>
+							<span className="font-mono text-[11px] text-fg-3">when</span>
+							<PathSelect
+								label={`Trigger field for rule ${i + 1}`}
+								paths={paths}
+								value={rule.when[0] ?? ""}
+								disabled={readOnly}
+								onChange={(p) => setRule(i, { ...rule, when: p ? [p] : [] })}
+							/>
+							<span className="font-mono text-[11px] text-fg-3">is present</span>
+							{!isRuleComplete(rule) && (
+								<span className="font-mono text-[10px] text-warn">incomplete</span>
+							)}
+							{!readOnly && (
+								<button
+									type="button"
+									onClick={() => removeRule(i)}
+									aria-label={`Remove rule ${i + 1}`}
+									className="ml-auto rounded-[var(--r-xs)] px-1.5 text-fg-3 hover:text-danger"
+								>
+									×
+								</button>
+							)}
+						</div>
+					))}
+				</div>
+
+				{!readOnly && (
+					<button
+						type="button"
+						onClick={addRule}
+						data-testid="add-rule"
+						className="mt-3 inline-flex items-center gap-1.5 rounded-[var(--r-sm)] border border-dashed border-line-2 px-3 py-1.5 text-xs font-medium text-fg-2 hover:bg-surface-2 hover:text-fg"
+					>
+						<svg
+							aria-hidden="true"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							className="h-3.5 w-3.5"
+						>
+							<path d="M12 5v14M5 12h14" />
+						</svg>
+						Add rule
+					</button>
+				)}
+
+				{rules.some(isRuleComplete) && (
+					<ul className="mt-3 space-y-1" data-testid="rules-summary">
+						{rules.filter(isRuleComplete).map((r) => (
+							<li key={summarizeRule(r)} className="font-mono text-[11px] text-fg-3">
+								{summarizeRule(r)}
+							</li>
+						))}
+					</ul>
+				)}
+			</Section>
+		</div>
+	);
+}
+
+function PathSelect({
+	label,
+	paths,
+	value,
+	disabled,
+	onChange,
+}: {
+	label: string;
+	paths: string[];
+	value: string;
+	disabled: boolean;
+	onChange: (path: string) => void;
+}) {
+	return (
+		<select
+			aria-label={label}
+			disabled={disabled}
+			value={value}
+			onChange={(e) => onChange(e.target.value)}
+			className={`${inputCls(disabled)} max-w-44 font-mono text-xs`}
+		>
+			<option value="">— field —</option>
+			{paths.map((p) => (
+				<option key={p} value={p}>
+					{p}
+				</option>
+			))}
+		</select>
+	);
+}
+
+// --- Publish modal -----------------------------------------------------------
+
+function PublishModal({
+	name,
+	version,
+	pending,
+	onCancel,
+	onConfirm,
+}: {
+	name: string;
+	version: number;
+	pending: boolean;
+	onCancel: () => void;
+	onConfirm: (note: string) => void;
+}) {
+	const [note, setNote] = useState("");
+	const titleId = useId();
+	return (
+		<div
+			className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby={titleId}
+			data-testid="publish-modal"
+		>
+			<div className="w-full max-w-md rounded-[var(--r-lg)] border border-line bg-surface shadow-[var(--sh-2)]">
+				<div className="flex items-center gap-2 border-b border-line px-4 py-3">
+					<svg
+						aria-hidden="true"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="var(--ok)"
+						strokeWidth="2"
+						className="h-4 w-4"
+					>
+						<path d="M12 19V5M5 12l7-7 7 7" />
+					</svg>
+					<h3 id={titleId} className="text-sm font-semibold text-fg">
+						Publish{" "}
+						<span className="font-mono">
+							{name} v{version}
+						</span>
+						?
+					</h3>
+				</div>
+				<div className="px-4 py-3 text-sm text-fg-2">
+					<p>
+						Publishing <b className="text-fg">freezes v{version} permanently</b> — its field
+						definitions become <b className="text-fg">immutable</b>. Future changes require a new
+						draft.
+					</p>
+					<p className="mt-2 flex items-start gap-2 text-xs text-fg-3">
+						<svg
+							aria-hidden="true"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							className="mt-0.5 h-3.5 w-3.5 flex-none"
+						>
+							<path d="M12 9v4m0 4h.01M10.3 3.9 2.4 18a2 2 0 0 0 1.7 3h15.8a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z" />
+						</svg>
+						<span>
+							This does <b>not</b> change any tenant's bound version. Existing tenants stay on their
+							current version until you migrate them.
+						</span>
+					</p>
+					<input
+						value={note}
+						onChange={(e) => setNote(e.target.value)}
+						aria-label="Changelog"
+						placeholder="Changelog — what changed? (recorded on the version)"
+						className="mt-3 w-full rounded-[var(--r-sm)] border border-line-2 bg-canvas px-3 py-1.5 text-sm text-fg outline-none focus:border-accent"
+					/>
+				</div>
+				<div className="flex justify-end gap-2 border-t border-line px-4 py-3">
+					<button
+						type="button"
+						onClick={onCancel}
+						className="rounded-[var(--r-sm)] border border-line-2 bg-surface-2 px-3 py-1.5 text-sm font-medium text-fg-2 hover:bg-surface-3"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						onClick={() => onConfirm(note)}
+						disabled={pending}
+						className="inline-flex items-center gap-1.5 rounded-[var(--r-sm)] bg-ok px-4 py-1.5 text-sm font-semibold text-white hover:brightness-110 disabled:opacity-50"
+						data-testid="publish-confirm"
+					>
+						<svg
+							aria-hidden="true"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							className="h-3.5 w-3.5"
+						>
+							<path d="M12 19V5M5 12l7-7 7 7" />
+						</svg>
+						{pending ? "Publishing…" : "Publish & freeze"}
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// --- Shared bits -------------------------------------------------------------
+
+function EmptyEditor({ onAdd }: { onAdd?: () => void }) {
+	return (
+		<div
+			data-testid="editor-empty"
+			className="rounded-[var(--r-md)] border border-dashed border-line-2 bg-surface px-6 py-16 text-center"
+		>
+			<p className="text-sm text-fg-2">Select a field to edit its definition.</p>
+			{onAdd && (
+				<button
+					type="button"
+					onClick={onAdd}
+					className="mt-3 inline-flex items-center gap-1.5 rounded-[var(--r-sm)] border border-line-2 bg-surface-2 px-3 py-1.5 text-xs font-medium text-fg hover:bg-surface-3"
+				>
+					<svg
+						aria-hidden="true"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						className="h-3.5 w-3.5"
+					>
+						<path d="M12 5v14M5 12h14" />
+					</svg>
+					Add the first field
+				</button>
+			)}
+		</div>
+	);
+}
+
+function Section({
+	num,
+	title,
+	hint,
+	children,
+}: {
+	num: number | string;
+	title: string;
+	hint?: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="rounded-[var(--r-md)] border border-line bg-surface">
+			<div className="flex items-center gap-2 border-b border-line px-3 py-2.5">
+				<span className="grid h-5 w-5 flex-none place-items-center rounded-[var(--r-xs)] bg-surface-3 font-mono text-[11px] text-fg-2">
+					{num}
+				</span>
+				<h3 className="text-sm font-semibold text-fg">{title}</h3>
+				{hint && <span className="ml-auto font-mono text-[11px] text-fg-3">{hint}</span>}
+			</div>
+			<div className="space-y-3 px-3 py-3">{children}</div>
+		</div>
+	);
+}
+
+function Row({ label, sub, children }: { label: string; sub: string; children: React.ReactNode }) {
+	return (
+		<div className="grid grid-cols-1 gap-1.5 sm:grid-cols-[10rem_minmax(0,1fr)] sm:items-start sm:gap-3">
+			<div className="pt-1.5">
+				<div className="text-[13px] text-fg-2">{label}</div>
+				{sub && <div className="font-mono text-[10px] text-fg-3">{sub}</div>}
+			</div>
+			<div className="min-w-0">{children}</div>
+		</div>
+	);
+}
+
+/** An add/remove set of string chips — used for enum values and URL allow-lists. */
+function ChipSet({
+	values,
+	readOnly,
+	placeholder,
+	testid,
+	onChange,
+}: {
+	values: string[];
+	readOnly: boolean;
+	placeholder: string;
+	testid: string;
+	onChange: (values: string[]) => void;
+}) {
+	const [entry, setEntry] = useState("");
+	const commit = () => {
+		const v = entry.trim();
+		if (v === "" || values.includes(v)) {
+			setEntry("");
+			return;
+		}
+		onChange([...values, v]);
+		setEntry("");
+	};
+	return (
+		<div className="flex flex-wrap items-center gap-1.5" data-testid={testid}>
+			{values.map((v) => (
+				<span
+					key={v}
+					className="inline-flex items-center gap-1 rounded-[var(--r-xs)] border border-line-2 bg-surface-2 px-2 py-0.5 font-mono text-[11px] text-fg-2"
+				>
+					{v}
+					{!readOnly && (
+						<button
+							type="button"
+							aria-label={`Remove ${v}`}
+							onClick={() => onChange(values.filter((x) => x !== v))}
+							className="text-fg-3 hover:text-danger"
+						>
+							×
+						</button>
+					)}
+				</span>
+			))}
+			{!readOnly && (
+				<input
+					aria-label={placeholder}
+					value={entry}
+					placeholder={placeholder}
+					onChange={(e) => setEntry(e.target.value)}
+					onKeyDown={(e) => {
+						if (e.key === "Enter") {
+							e.preventDefault();
+							commit();
+						}
+					}}
+					onBlur={commit}
+					className={`${inputCls(false)} w-32 font-mono text-xs`}
+				/>
+			)}
+		</div>
+	);
+}
+
+function Toggle({
+	label,
+	checked,
+	disabled,
+	onChange,
+}: {
+	label: string;
+	checked: boolean;
+	disabled: boolean;
+	onChange: (checked: boolean) => void;
+}) {
+	return (
+		<label className="inline-flex cursor-pointer items-center gap-2 text-[11px] text-fg-2">
+			<input
+				type="checkbox"
+				aria-label={label}
+				checked={checked}
+				disabled={disabled}
+				onChange={(e) => onChange(e.target.checked)}
+				className="peer sr-only"
+			/>
+			<span
+				className={`relative h-[18px] w-[32px] flex-none rounded-[var(--r-pill)] border transition-colors ${
+					checked ? "border-transparent bg-accent" : "border-line-2 bg-surface-3"
+				} peer-disabled:opacity-50`}
+			>
+				<span
+					className={`absolute top-0.5 left-0.5 h-3 w-3 rounded-full transition-transform ${
+						checked ? "translate-x-3.5 bg-white" : "bg-fg-3"
+					}`}
+				/>
+			</span>
+		</label>
+	);
+}
+
+function inputCls(_disabled: boolean): string {
+	return "rounded-[var(--r-sm)] border border-line-2 bg-surface px-3 py-1.5 text-sm text-fg outline-none focus:border-accent disabled:cursor-not-allowed disabled:bg-surface-2 disabled:text-fg-3";
+}

--- a/src/pages/schemas/SchemaDetail.tsx
+++ b/src/pages/schemas/SchemaDetail.tsx
@@ -91,6 +91,15 @@ export function SchemaDetail() {
 							<SchemaInfoBlock info={schema.info} />
 						</div>
 						<div className="flex gap-2">
+							{canManageSchemas(auth.role) && (
+								<Link
+									to={`/schemas/${id}/author`}
+									className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+									data-testid="author-link"
+								>
+									{schema.published ? "New draft" : "Edit in workbench"}
+								</Link>
+							)}
 							{!schema.published && canManageSchemas(auth.role) && (
 								<button
 									type="button"

--- a/src/pages/schemas/__tests__/SchemaAuthor.test.tsx
+++ b/src/pages/schemas/__tests__/SchemaAuthor.test.tsx
@@ -1,0 +1,569 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { type ReactNode, useState } from "react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../../../api/schema";
+import { AuthContext, type AuthContextValue } from "../../../lib/auth";
+import type { Role } from "../../../lib/constants";
+import { ToastProvider } from "../../../lib/toast";
+import { SchemaAuthor } from "../SchemaAuthor";
+
+type SchemaField = components["schemas"]["v1SchemaField"];
+type Schema = components["schemas"]["v1Schema"];
+
+const SCHEMA_ID = "11111111-1111-1111-1111-111111111111";
+
+// A draft schema exercising every field type + every flag.
+const draftFields: SchemaField[] = [
+	{
+		path: "app.name",
+		title: "Application Name",
+		type: "FIELD_TYPE_STRING",
+		tags: ["general"],
+		description: "Display name.",
+		constraints: { minLength: 1, maxLength: 100 },
+		defaultValue: "MyApp",
+	},
+	{
+		path: "app.version",
+		title: "App Version",
+		type: "FIELD_TYPE_STRING",
+		tags: ["general"],
+		readOnly: true,
+		constraints: { regex: "^\\d+\\.\\d+$" },
+	},
+	{
+		path: "payments.retries",
+		title: "Retries",
+		type: "FIELD_TYPE_INT",
+		tags: ["payments"],
+		constraints: { min: 0, max: 10 },
+	},
+	{
+		path: "payments.fee_rate",
+		title: "Fee Rate",
+		type: "FIELD_TYPE_NUMBER",
+		tags: ["payments"],
+		constraints: { min: 0, max: 100 },
+	},
+	{ path: "payments.enabled", title: "Enabled", type: "FIELD_TYPE_BOOL", tags: ["payments"] },
+	{
+		path: "payments.currency",
+		title: "Currency",
+		type: "FIELD_TYPE_STRING",
+		tags: ["payments"],
+		writeOnce: true,
+		constraints: { enumValues: ["USD", "EUR"] },
+	},
+	{
+		path: "settlement.window",
+		title: "Window",
+		type: "FIELD_TYPE_DURATION",
+		tags: ["settlement"],
+		constraints: { min: 3600 },
+	},
+	{ path: "settlement.cutoff", title: "Cutoff", type: "FIELD_TYPE_TIME", tags: ["settlement"] },
+	{ path: "api.webhook_url", title: "Webhook URL", type: "FIELD_TYPE_URL", tags: ["api"] },
+	{
+		path: "api.rate_limits",
+		title: "Rate Limits",
+		type: "FIELD_TYPE_JSON",
+		tags: ["api"],
+		sensitive: true,
+		constraints: { jsonSchema: '{"type":"object"}' },
+	},
+	{
+		path: "legacy.old_fee",
+		title: "Old Fee",
+		type: "FIELD_TYPE_NUMBER",
+		tags: ["legacy"],
+		deprecated: true,
+		redirectTo: "payments.fee_rate",
+	},
+];
+
+const draftSchema: Schema = {
+	id: SCHEMA_ID,
+	name: "showcase",
+	version: 2,
+	parentVersion: 1,
+	published: false,
+	fields: draftFields,
+};
+
+const publishedSchema: Schema = {
+	...draftSchema,
+	version: 1,
+	parentVersion: undefined,
+	published: true,
+};
+
+// --- Mutable mocks --------------------------------------------------------------
+
+let mockSchema: Schema | undefined = draftSchema;
+let mockLoading = false;
+let mockError: Error | null = null;
+const mockClient = { PATCH: vi.fn(), POST: vi.fn(), GET: vi.fn() };
+
+vi.mock("../../../lib/hooks", () => ({
+	useApiClient: () => mockClient,
+	useSchema: () => ({ data: { schema: mockSchema }, isLoading: mockLoading, error: mockError }),
+}));
+
+beforeEach(() => {
+	mockSchema = draftSchema;
+	mockLoading = false;
+	mockError = null;
+	mockClient.PATCH.mockReset();
+	mockClient.POST.mockReset();
+	mockClient.GET.mockReset();
+});
+
+function renderAuthor(role: Role = "superadmin") {
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	function Harness({ children }: { children: ReactNode }) {
+		const [auth] = useState({ subject: "root", role, tenantId: "" });
+		const ctx: AuthContextValue = { auth, setAuth: () => {} };
+		return <AuthContext value={ctx}>{children}</AuthContext>;
+	}
+	return render(
+		<QueryClientProvider client={qc}>
+			<ToastProvider>
+				<Harness>
+					<MemoryRouter initialEntries={[`/schemas/${SCHEMA_ID}/author`]}>
+						<Routes>
+							<Route path="/schemas/:id/author" element={<SchemaAuthor />} />
+							<Route path="/schemas" element={<div>schemas list</div>} />
+						</Routes>
+					</MemoryRouter>
+				</Harness>
+			</ToastProvider>
+		</QueryClientProvider>,
+	);
+}
+
+/** Select a field in the left list by path. */
+function selectField(path: string) {
+	fireEvent.click(screen.getByTestId(`field-item-${path}`));
+}
+
+describe("SchemaAuthor — permission gate", () => {
+	it("renders the workbench for superadmin", () => {
+		renderAuthor("superadmin");
+		expect(screen.getByTestId("schema-author-page")).toBeInTheDocument();
+	});
+
+	it("refuses admin with a clear message, not a disabled editor", () => {
+		renderAuthor("admin");
+		expect(screen.getByTestId("schema-author-denied")).toBeInTheDocument();
+		expect(screen.queryByTestId("schema-author-page")).toBeNull();
+	});
+
+	it("refuses user", () => {
+		renderAuthor("user");
+		expect(screen.getByTestId("schema-author-denied")).toBeInTheDocument();
+	});
+});
+
+describe("SchemaAuthor — loading & error", () => {
+	it("shows a skeleton while loading", () => {
+		mockLoading = true;
+		const { container } = renderAuthor();
+		expect(container.querySelector(".animate-pulse")).toBeInTheDocument();
+	});
+
+	it("shows an error message when the query fails", () => {
+		mockError = new Error("schema gone");
+		renderAuthor();
+		expect(screen.getByTestId("schema-author-error")).toHaveTextContent("schema gone");
+	});
+
+	it("renders nothing when the schema is absent", () => {
+		mockSchema = undefined;
+		const { container } = renderAuthor();
+		expect(container.querySelector('[data-testid="schema-author-page"]')).toBeNull();
+	});
+});
+
+describe("SchemaAuthor — field list", () => {
+	it("renders the field count and a grouped list", () => {
+		renderAuthor();
+		expect(screen.getByTestId("field-count")).toHaveTextContent("11 · 8 types");
+		expect(screen.getByTestId("field-item-app.name")).toBeInTheDocument();
+		expect(screen.getByTestId("field-item-api.rate_limits")).toBeInTheDocument();
+		expect(screen.getByTestId("field-item-rules")).toBeInTheDocument();
+	});
+
+	it("shows the empty editor until a field is selected", () => {
+		renderAuthor();
+		expect(screen.getByTestId("editor-empty")).toBeInTheDocument();
+	});
+});
+
+describe("SchemaAuthor — lifecycle bar", () => {
+	it("shows the draft state and editable affordance for a draft", () => {
+		renderAuthor();
+		expect(screen.getByTestId("lifecycle-state")).toHaveTextContent("v2 · draft");
+		expect(screen.getByText("forked from v1")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /Publish v2/ })).toBeInTheDocument();
+	});
+
+	it("shows the published immutable state and a New draft fork action", () => {
+		mockSchema = publishedSchema;
+		renderAuthor();
+		expect(screen.getByTestId("lifecycle-state")).toHaveTextContent("v1 · published");
+		expect(screen.getByTestId("immutable-banner")).toBeInTheDocument();
+		expect(screen.getByTestId("fork-btn")).toBeInTheDocument();
+		// No publish/save on a published version.
+		expect(screen.queryByRole("button", { name: /Publish v/ })).toBeNull();
+		expect(screen.queryByRole("button", { name: /Save draft/ })).toBeNull();
+	});
+});
+
+describe("SchemaAuthor — type-adaptive constraint editor", () => {
+	it("shows min/max + exclusive toggles for an int", () => {
+		renderAuthor();
+		selectField("payments.retries");
+		const editor = screen.getByTestId("field-editor");
+		expect(within(editor).getByLabelText("Minimum")).toHaveValue(0);
+		expect(within(editor).getByLabelText("Maximum")).toHaveValue(10);
+		expect(within(editor).getAllByLabelText("exclusive")).toHaveLength(2);
+	});
+
+	it("shows length + pattern + enum for a string", () => {
+		renderAuthor();
+		selectField("app.name");
+		const editor = screen.getByTestId("field-editor");
+		expect(within(editor).getByLabelText("Minimum length")).toHaveValue(1);
+		expect(within(editor).getByLabelText("Pattern")).toBeInTheDocument();
+		expect(within(editor).getByTestId("enum-chips")).toBeInTheDocument();
+	});
+
+	it("shows a JSON Schema textarea for a json field", () => {
+		renderAuthor();
+		selectField("api.rate_limits");
+		expect(screen.getByLabelText("JSON Schema")).toHaveValue('{"type":"object"}');
+	});
+
+	it("shows a URL allow-list chip set for a url field", () => {
+		renderAuthor();
+		selectField("api.webhook_url");
+		expect(screen.getByTestId("url-enum-chips")).toBeInTheDocument();
+	});
+
+	it("shows the duration second-bounds editor", () => {
+		renderAuthor();
+		selectField("settlement.window");
+		expect(screen.getByLabelText("Minimum")).toHaveValue(3600);
+	});
+
+	it("shows 'no constraints' for bool and time", () => {
+		renderAuthor();
+		selectField("payments.enabled");
+		expect(screen.getByTestId("no-constraints")).toHaveTextContent(/Booleans take no constraints/);
+		selectField("settlement.cutoff");
+		expect(screen.getByTestId("no-constraints")).toHaveTextContent(/RFC 3339/);
+	});
+
+	it("adapts the constraint section when the type changes", () => {
+		renderAuthor();
+		selectField("app.name"); // string → has Pattern
+		expect(screen.getByLabelText("Pattern")).toBeInTheDocument();
+		fireEvent.click(screen.getByTestId("type-FIELD_TYPE_INT"));
+		// Now numeric → Pattern is gone, Minimum appears.
+		expect(screen.queryByLabelText("Pattern")).toBeNull();
+		expect(screen.getByLabelText("Minimum")).toBeInTheDocument();
+	});
+});
+
+describe("SchemaAuthor — metadata + flags editing", () => {
+	it("edits the title and marks the draft dirty with a diff summary", () => {
+		renderAuthor();
+		selectField("app.name");
+		fireEvent.change(screen.getByLabelText("Title"), { target: { value: "Renamed" } });
+		expect(screen.getByTestId("dirty-note")).toBeInTheDocument();
+		expect(screen.getByTestId("diff-summary")).toHaveTextContent("~1 changed");
+	});
+
+	it("edits tags from a comma-separated input", () => {
+		renderAuthor();
+		selectField("app.name");
+		const tags = screen.getByLabelText("Tags");
+		expect(tags).toHaveValue("general");
+		fireEvent.change(tags, { target: { value: "general, billing" } });
+		expect(screen.getByTestId("diff-summary")).toHaveTextContent("~1 changed");
+	});
+
+	it("renders all five flags and toggles one on", () => {
+		renderAuthor();
+		selectField("app.name");
+		for (const k of ["nullable", "readOnly", "writeOnce", "sensitive", "deprecated"]) {
+			expect(screen.getByTestId(`flag-${k}`)).toBeInTheDocument();
+		}
+		const nullableToggle = within(screen.getByTestId("flag-nullable")).getByLabelText("Nullable");
+		fireEvent.click(nullableToggle);
+		expect(screen.getByTestId("diff-summary")).toHaveTextContent("~1 changed");
+	});
+
+	it("reveals the redirect_to input when deprecated is toggled on, and clears it when off", () => {
+		renderAuthor();
+		selectField("app.name");
+		const card = screen.getByTestId("flag-deprecated");
+		fireEvent.click(within(card).getByLabelText("Deprecated"));
+		const redirect = within(card).getByLabelText("Redirect to");
+		fireEvent.change(redirect, { target: { value: "payments.fee_rate" } });
+		expect(redirect).toHaveValue("payments.fee_rate");
+		// Toggle off → input gone.
+		fireEvent.click(within(card).getByLabelText("Deprecated"));
+		expect(within(card).queryByLabelText("Redirect to")).toBeNull();
+	});
+
+	it("shows the existing redirect target for an already-deprecated field", () => {
+		renderAuthor();
+		selectField("legacy.old_fee");
+		expect(screen.getByLabelText("Redirect to")).toHaveValue("payments.fee_rate");
+	});
+
+	it("edits an enum chip set — add and remove", () => {
+		renderAuthor();
+		selectField("payments.currency");
+		const chips = screen.getByTestId("enum-chips");
+		expect(within(chips).getByText("USD")).toBeInTheDocument();
+		// Add a value.
+		const entry = within(chips).getByLabelText("add value");
+		fireEvent.change(entry, { target: { value: "GBP" } });
+		fireEvent.keyDown(entry, { key: "Enter" });
+		expect(within(chips).getByText("GBP")).toBeInTheDocument();
+		// Remove a value.
+		fireEvent.click(within(chips).getByLabelText("Remove USD"));
+		expect(within(chips).queryByText("USD")).toBeNull();
+	});
+});
+
+describe("SchemaAuthor — add & delete fields", () => {
+	it("adds a new field, selects it, and counts it", () => {
+		renderAuthor();
+		fireEvent.click(screen.getByTestId("add-field"));
+		expect(screen.getByTestId("field-item-new.field_1")).toBeInTheDocument();
+		expect(screen.getByTestId("field-editor")).toBeInTheDocument();
+		expect(screen.getByTestId("diff-summary")).toHaveTextContent("+1 added");
+	});
+
+	it("deletes a field and reflects it as removed", () => {
+		renderAuthor();
+		selectField("legacy.old_fee");
+		fireEvent.click(screen.getByTestId("delete-field"));
+		expect(screen.queryByTestId("field-item-legacy.old_fee")).toBeNull();
+		expect(screen.getByTestId("diff-summary")).toHaveTextContent("−1 removed");
+	});
+
+	it("can add the first field from the empty editor", () => {
+		renderAuthor();
+		fireEvent.click(within(screen.getByTestId("editor-empty")).getByRole("button"));
+		expect(screen.getByTestId("field-editor")).toBeInTheDocument();
+	});
+});
+
+describe("SchemaAuthor — definition validation", () => {
+	it("flags a duplicate path and blocks Save", () => {
+		renderAuthor();
+		selectField("app.version");
+		fireEvent.change(screen.getByLabelText("Path"), { target: { value: "app.name" } });
+		// Editing the path keeps the field selected; the dup error shows on it.
+		expect(screen.getByTestId("field-editor-error")).toHaveTextContent(/Duplicate path/);
+		// Both colliding list items get an error dot.
+		expect(screen.getAllByTestId("field-error-dot-app.name").length).toBeGreaterThanOrEqual(1);
+		expect(screen.getByRole("button", { name: /Save draft/ })).toBeDisabled();
+	});
+
+	it("flags an invalid regex pattern", () => {
+		renderAuthor();
+		selectField("app.name");
+		fireEvent.change(screen.getByLabelText("Pattern"), { target: { value: "(" } });
+		expect(screen.getByTestId("field-editor-error")).toHaveTextContent(/valid regular expression/);
+	});
+});
+
+describe("SchemaAuthor — Save draft (UpdateSchema)", () => {
+	it("is disabled when the draft is clean", () => {
+		renderAuthor();
+		expect(screen.getByRole("button", { name: /Save draft/ })).toBeDisabled();
+	});
+
+	it("PATCHes only the changed-field delta and toasts the new draft version", async () => {
+		mockClient.PATCH.mockResolvedValue({ data: { schema: { version: 3 } }, error: undefined });
+		renderAuthor();
+		selectField("app.name");
+		fireEvent.change(screen.getByLabelText("Title"), { target: { value: "Renamed" } });
+		fireEvent.click(screen.getByRole("button", { name: /Save draft/ }));
+
+		await waitFor(() => expect(mockClient.PATCH).toHaveBeenCalledTimes(1));
+		const [path, opts] = mockClient.PATCH.mock.calls[0];
+		expect(path).toBe("/v1/schemas/{id}");
+		expect(opts.params.path.id).toBe(SCHEMA_ID);
+		expect(opts.body.fields).toHaveLength(1);
+		expect(opts.body.fields[0].path).toBe("app.name");
+		expect(opts.body.fields[0].title).toBe("Renamed");
+		expect(await screen.findByText(/draft v3 created/)).toBeInTheDocument();
+	});
+
+	it("sends removeFields when a field is deleted", async () => {
+		mockClient.PATCH.mockResolvedValue({ data: { schema: { version: 3 } }, error: undefined });
+		renderAuthor();
+		selectField("legacy.old_fee");
+		fireEvent.click(screen.getByTestId("delete-field"));
+		fireEvent.click(screen.getByRole("button", { name: /Save draft/ }));
+		await waitFor(() => expect(mockClient.PATCH).toHaveBeenCalledTimes(1));
+		expect(mockClient.PATCH.mock.calls[0][1].body.removeFields).toEqual(["legacy.old_fee"]);
+	});
+
+	it("surfaces a save error toast", async () => {
+		mockClient.PATCH.mockResolvedValue({ data: undefined, error: { message: "boom" } });
+		renderAuthor();
+		selectField("app.name");
+		fireEvent.change(screen.getByLabelText("Title"), { target: { value: "X" } });
+		fireEvent.click(screen.getByRole("button", { name: /Save draft/ }));
+		expect(await screen.findByText(/Save failed: boom/)).toBeInTheDocument();
+	});
+
+	it("discards local changes with the lifecycle reset action", () => {
+		renderAuthor();
+		selectField("app.name");
+		fireEvent.change(screen.getByLabelText("Title"), { target: { value: "Renamed" } });
+		expect(screen.getByTestId("dirty-note")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: /discard changes/ }));
+		expect(screen.queryByTestId("dirty-note")).toBeNull();
+	});
+});
+
+describe("SchemaAuthor — Publish (immutable, no rebind)", () => {
+	it("opens a confirm modal that states publishing does not rebind tenants", () => {
+		renderAuthor();
+		fireEvent.click(screen.getByRole("button", { name: /Publish v2/ }));
+		const modal = screen.getByTestId("publish-modal");
+		expect(within(modal).getByText(/freezes v2 permanently/)).toBeInTheDocument();
+		expect(within(modal).getByText(/does/)).toBeInTheDocument();
+		expect(within(modal).getByText(/stay on/)).toBeInTheDocument();
+	});
+
+	it("publishing is blocked while the draft has unsaved changes", () => {
+		renderAuthor();
+		selectField("app.name");
+		fireEvent.change(screen.getByLabelText("Title"), { target: { value: "X" } });
+		expect(screen.getByRole("button", { name: /Publish v2/ })).toBeDisabled();
+	});
+
+	it("POSTs the publish with the draft version on confirm", async () => {
+		mockClient.POST.mockResolvedValue({ data: {}, error: undefined });
+		renderAuthor();
+		fireEvent.click(screen.getByRole("button", { name: /Publish v2/ }));
+		fireEvent.click(screen.getByTestId("publish-confirm"));
+		await waitFor(() => expect(mockClient.POST).toHaveBeenCalledTimes(1));
+		const [path, opts] = mockClient.POST.mock.calls[0];
+		expect(path).toBe("/v1/schemas/{id}/publish");
+		expect(opts.body.version).toBe(2);
+		expect(await screen.findByText(/Published v2 — now immutable/)).toBeInTheDocument();
+	});
+
+	it("cancels the publish modal without POSTing", () => {
+		renderAuthor();
+		fireEvent.click(screen.getByRole("button", { name: /Publish v2/ }));
+		fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+		expect(screen.queryByTestId("publish-modal")).toBeNull();
+		expect(mockClient.POST).not.toHaveBeenCalled();
+	});
+
+	it("toasts an error when publish fails", async () => {
+		mockClient.POST.mockResolvedValue({ data: undefined, error: { message: "nope" } });
+		renderAuthor();
+		fireEvent.click(screen.getByRole("button", { name: /Publish v2/ }));
+		fireEvent.click(screen.getByTestId("publish-confirm"));
+		expect(await screen.findByText(/Publish failed: nope/)).toBeInTheDocument();
+	});
+});
+
+describe("SchemaAuthor — published version is read-only", () => {
+	beforeEach(() => {
+		mockSchema = publishedSchema;
+	});
+
+	it("disables the editor inputs and the type picker", () => {
+		renderAuthor();
+		selectField("app.name");
+		expect(screen.getByLabelText("Title")).toBeDisabled();
+		expect(screen.getByTestId("type-FIELD_TYPE_INT")).toBeDisabled();
+	});
+
+	it("hides Add field and Delete field on a published version", () => {
+		renderAuthor();
+		expect(screen.queryByTestId("add-field")).toBeNull();
+		selectField("app.name");
+		expect(screen.queryByTestId("delete-field")).toBeNull();
+	});
+
+	it("forks a published version into a new draft via UpdateSchema", async () => {
+		mockClient.PATCH.mockResolvedValue({ data: { schema: { version: 2 } }, error: undefined });
+		renderAuthor();
+		fireEvent.click(screen.getByTestId("fork-btn"));
+		await waitFor(() => expect(mockClient.PATCH).toHaveBeenCalledTimes(1));
+		expect(mockClient.PATCH.mock.calls[0][1].body.versionDescription).toMatch(/Draft from v1/);
+		expect(await screen.findByText(/New draft v2 created/)).toBeInTheDocument();
+	});
+
+	it("forks from the in-banner New draft button too", async () => {
+		mockClient.PATCH.mockResolvedValue({ data: { schema: { version: 2 } }, error: undefined });
+		renderAuthor();
+		fireEvent.click(within(screen.getByTestId("immutable-banner")).getByRole("button"));
+		await waitFor(() => expect(mockClient.PATCH).toHaveBeenCalledTimes(1));
+	});
+
+	it("toasts an error when the fork fails", async () => {
+		mockClient.PATCH.mockResolvedValue({ data: undefined, error: { message: "locked" } });
+		renderAuthor();
+		fireEvent.click(screen.getByTestId("fork-btn"));
+		expect(await screen.findByText(/Could not fork: locked/)).toBeInTheDocument();
+	});
+});
+
+describe("SchemaAuthor — dependent_required rule builder", () => {
+	it("shows the empty state and the not-persisted degradation note", () => {
+		renderAuthor();
+		fireEvent.click(screen.getByTestId("field-item-rules"));
+		expect(screen.getByTestId("dependent-rules")).toBeInTheDocument();
+		expect(screen.getByTestId("rules-empty")).toBeInTheDocument();
+		expect(screen.getByTestId("dependent-required-note")).toHaveTextContent(/not persisted/);
+	});
+
+	it("adds a complete rule and summarizes it", () => {
+		renderAuthor();
+		fireEvent.click(screen.getByTestId("field-item-rules"));
+		fireEvent.click(screen.getByTestId("add-rule"));
+		const row = screen.getByTestId("rule-0");
+		fireEvent.change(within(row).getByLabelText(/Required field for rule 1/), {
+			target: { value: "api.webhook_url" },
+		});
+		fireEvent.change(within(row).getByLabelText(/Trigger field for rule 1/), {
+			target: { value: "payments.enabled" },
+		});
+		expect(screen.getByTestId("rules-summary")).toHaveTextContent(
+			"require api.webhook_url when payments.enabled present",
+		);
+	});
+
+	it("removes a rule", () => {
+		renderAuthor();
+		fireEvent.click(screen.getByTestId("field-item-rules"));
+		fireEvent.click(screen.getByTestId("add-rule"));
+		expect(screen.getByTestId("rule-0")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: /Remove rule 1/ }));
+		expect(screen.queryByTestId("rule-0")).toBeNull();
+	});
+
+	it("hides the rule controls on a published (read-only) schema", () => {
+		mockSchema = publishedSchema;
+		renderAuthor();
+		fireEvent.click(screen.getByTestId("field-item-rules"));
+		expect(screen.queryByTestId("add-rule")).toBeNull();
+	});
+});

--- a/src/pages/schemas/__tests__/SchemaDetail.test.tsx
+++ b/src/pages/schemas/__tests__/SchemaDetail.test.tsx
@@ -1,0 +1,187 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { type ReactNode, useState } from "react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../../../api/schema";
+import { AuthContext, type AuthContextValue } from "../../../lib/auth";
+import type { Role } from "../../../lib/constants";
+import { ToastProvider } from "../../../lib/toast";
+import { SchemaDetail } from "../SchemaDetail";
+
+type Schema = components["schemas"]["v1Schema"];
+
+const SCHEMA_ID = "22222222-2222-2222-2222-222222222222";
+
+const draftSchema: Schema = {
+	id: SCHEMA_ID,
+	name: "showcase",
+	version: 2,
+	published: false,
+	checksum: "abc123",
+	createdAt: "2026-01-15T00:00:00Z",
+	info: { title: "Showcase", author: "platform" },
+	fields: [
+		{
+			path: "app.name",
+			title: "Application Name",
+			type: "FIELD_TYPE_STRING",
+			tags: ["general"],
+			description: "Display name.",
+			constraints: { minLength: 1, maxLength: 100 },
+			defaultValue: "MyApp",
+			example: "Demo",
+			readOnly: false,
+		},
+		{
+			path: "payments.fee_rate",
+			title: "Fee Rate",
+			type: "FIELD_TYPE_NUMBER",
+			tags: ["payments"],
+			constraints: { min: 0, max: 100 },
+			deprecated: true,
+			redirectTo: "payments.rate",
+			sensitive: true,
+			writeOnce: true,
+		},
+	],
+};
+
+const publishedSchema: Schema = { ...draftSchema, version: 1, published: true };
+
+let mockSchema: Schema | undefined = draftSchema;
+let mockLoading = false;
+let mockError: Error | null = null;
+const mockClient = { POST: vi.fn(), GET: vi.fn() };
+
+vi.mock("../../../lib/hooks", () => ({
+	useApiClient: () => mockClient,
+	useSchema: () => ({ data: { schema: mockSchema }, isLoading: mockLoading, error: mockError }),
+}));
+
+beforeEach(() => {
+	mockSchema = draftSchema;
+	mockLoading = false;
+	mockError = null;
+	mockClient.POST.mockReset();
+	mockClient.GET.mockReset();
+});
+
+function renderDetail(role: Role = "superadmin") {
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	function Harness({ children }: { children: ReactNode }) {
+		const [auth] = useState({ subject: "root", role, tenantId: "" });
+		const ctx: AuthContextValue = { auth, setAuth: () => {} };
+		return <AuthContext value={ctx}>{children}</AuthContext>;
+	}
+	return render(
+		<QueryClientProvider client={qc}>
+			<ToastProvider>
+				<Harness>
+					<MemoryRouter initialEntries={[`/schemas/${SCHEMA_ID}`]}>
+						<Routes>
+							<Route path="/schemas/:id" element={<SchemaDetail />} />
+							<Route path="/schemas/:id/author" element={<div data-testid="author-page" />} />
+						</Routes>
+					</MemoryRouter>
+				</Harness>
+			</ToastProvider>
+		</QueryClientProvider>,
+	);
+}
+
+describe("SchemaDetail — render", () => {
+	it("shows the schema name, info, version, and fields", () => {
+		renderDetail();
+		expect(screen.getByTestId("schema-detail-page")).toBeInTheDocument();
+		expect(screen.getByText("showcase")).toBeInTheDocument();
+		expect(screen.getByText("Showcase")).toBeInTheDocument();
+		expect(screen.getByText("v2")).toBeInTheDocument();
+		expect(screen.getByText("app.name")).toBeInTheDocument();
+		expect(screen.getByText("abc123", { exact: false })).toBeInTheDocument();
+	});
+
+	it("expands a field row to reveal its details", () => {
+		renderDetail();
+		fireEvent.click(screen.getByText("app.name"));
+		expect(screen.getByText(/Default/)).toBeInTheDocument();
+		expect(screen.getByText("Demo")).toBeInTheDocument();
+	});
+
+	it("shows a loading skeleton", () => {
+		mockLoading = true;
+		const { container } = renderDetail();
+		expect(container.querySelector(".animate-pulse")).toBeInTheDocument();
+	});
+
+	it("shows an error message", () => {
+		mockError = new Error("nope");
+		renderDetail();
+		expect(screen.getByText(/Error loading schema: nope/)).toBeInTheDocument();
+	});
+});
+
+describe("SchemaDetail — authoring entry point (superadmin only)", () => {
+	it("links a draft to the authoring workbench with an Edit affordance", () => {
+		renderDetail("superadmin");
+		const link = screen.getByTestId("author-link");
+		expect(link).toHaveTextContent("Edit in workbench");
+		expect(link).toHaveAttribute("href", `/schemas/${SCHEMA_ID}/author`);
+	});
+
+	it("labels the link 'New draft' for a published schema", () => {
+		mockSchema = publishedSchema;
+		renderDetail("superadmin");
+		expect(screen.getByTestId("author-link")).toHaveTextContent("New draft");
+	});
+
+	it("hides the authoring link for admin and user", () => {
+		renderDetail("admin");
+		expect(screen.queryByTestId("author-link")).toBeNull();
+		renderDetail("user");
+		expect(screen.queryByTestId("author-link")).toBeNull();
+	});
+});
+
+describe("SchemaDetail — publish + export", () => {
+	it("shows Publish only for an unpublished schema and POSTs on click", async () => {
+		mockClient.POST.mockResolvedValue({ data: { schema: {} }, error: undefined });
+		renderDetail("superadmin");
+		fireEvent.click(screen.getByRole("button", { name: "Publish" }));
+		await waitFor(() => expect(mockClient.POST).toHaveBeenCalledTimes(1));
+		expect(mockClient.POST.mock.calls[0][0]).toBe("/v1/schemas/{id}/publish");
+	});
+
+	it("hides Publish for an already-published schema", () => {
+		mockSchema = publishedSchema;
+		renderDetail("superadmin");
+		expect(screen.queryByRole("button", { name: "Publish" })).toBeNull();
+	});
+
+	it("exports the schema YAML on click", async () => {
+		mockClient.GET.mockResolvedValue({ data: { yamlContent: "name: showcase" }, error: undefined });
+		const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+		vi.stubGlobal("URL", {
+			createObjectURL: vi.fn(() => "blob:mock"),
+			revokeObjectURL: vi.fn(),
+		});
+		renderDetail("superadmin");
+		fireEvent.click(screen.getByRole("button", { name: /Export/ }));
+		await waitFor(() => expect(clickSpy).toHaveBeenCalled());
+		clickSpy.mockRestore();
+		vi.unstubAllGlobals();
+	});
+
+	it("links to the tenants using this schema", () => {
+		renderDetail();
+		const link = screen.getByRole("link", { name: /View tenants using this schema/ });
+		expect(link).toHaveAttribute("href", `/schemas/${SCHEMA_ID}/tenants`);
+	});
+
+	it("shows a deprecated badge on a deprecated field", () => {
+		renderDetail();
+		const feeRow = screen.getByText("payments.fee_rate").closest("tr");
+		expect(feeRow).not.toBeNull();
+		expect(within(feeRow as HTMLElement).getByText("Deprecated")).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Summary
- Adds the superadmin schema-authoring workbench (hi-fi Screen 5) at `/schemas/:id/author`: a two-pane field list + adaptive per-type constraint editor for all eight field types, the full metadata/flags grid, and the draft → publish lifecycle. The existing schema list / import / detail screens are kept (additive change).
- Lifecycle wired to the real gateway: Save draft = `UpdateSchema` (PATCH, delta-only — changed/added fields plus removed paths), which forks a NEW draft from the latest version; Publish = `PublishSchema` (POST), which freezes the version (immutable) and does NOT rebind existing tenants. Published versions render read-only with a "New draft" fork.
- A `dependent_required` (presence-triggered) rule builder is included.

## Test plan
- `npm run pre-commit` green (Biome, `tsc -b --noEmit`, vitest 359/359, vite build).
- New schema-authoring lib + workbench + detail-link tests; codecov patch ≥ 80% on changed lines. E2E smoke untouched (additive route; the schema list/import selectors are preserved).

## Notes
- `dependent_required` is not yet exposed by the REST gateway (absent from `schema.d.ts` / `openapi.json`), so the rule builder authors rules client-side with a visible "not persisted" banner — no endpoint invented. Server follow-up: add `dependent_required` to `UpdateSchema` / `v1SchemaField`, after which the builder persists.

Closes #93
