### PR TITLE
feat: transient-states coverage

### DIFF
--- a/src/__tests__/ReadView.test.tsx
+++ b/src/__tests__/ReadView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ReadView } from "../pages/ReadView";
 
@@ -37,6 +37,30 @@ const schema = {
 			title: "Cutoff Time",
 			type: "FIELD_TYPE_TIME",
 			tags: ["settlement"],
+			nullable: true,
+		},
+		{
+			// Deliberately cleared (explicit null) — nullable so the state is legal.
+			path: "settlement.window",
+			title: "Settlement Window",
+			type: "FIELD_TYPE_DURATION",
+			tags: ["settlement"],
+			nullable: true,
+		},
+		{ path: "api.overrides", title: "Overrides", type: "FIELD_TYPE_JSON", tags: ["api"] },
+		{
+			path: "settlement.timeout",
+			title: "Settlement Timeout",
+			type: "FIELD_TYPE_DURATION",
+			tags: ["settlement"],
+		},
+		{
+			path: "flags.legacy_mode",
+			title: "Legacy Mode",
+			type: "FIELD_TYPE_STRING",
+			tags: ["flags"],
+			deprecated: true,
+			redirectTo: "flags.tier",
 		},
 	],
 };
@@ -54,6 +78,8 @@ const config = {
 		},
 		// Sensitive: the server already redacted this to the literal [REDACTED].
 		{ fieldPath: "api.rate_limits", value: { jsonValue: "[REDACTED]" } },
+		{ fieldPath: "api.overrides", value: { jsonValue: '{"flag":true}' }, checksum: "0fac0fac" },
+		{ fieldPath: "settlement.timeout", value: { durationValue: "86400s" }, checksum: "ddeeffaa" },
 		// settlement.cutoff_time intentionally absent → unset / resolves to default.
 	],
 };
@@ -79,6 +105,45 @@ const audit = {
 			newValue: "OpenDecree Demo",
 			configVersion: 7,
 			createdAt: new Date(Date.now() - 3_600_000).toISOString(),
+		},
+		{
+			// A deliberate clear of settlement.window: had a value, new value empty →
+			// explicit null (provenance distinguishes it from a never-set field).
+			id: "e3",
+			actor: "bob@acme",
+			action: "set_field",
+			fieldPath: "settlement.window",
+			oldValue: "24h",
+			newValue: "",
+			configVersion: 7,
+			createdAt: new Date(Date.now() - 7_200_000).toISOString(),
+		},
+		{
+			// A days-old change → exercises the "Nd ago" branch of timeAgo.
+			id: "e4",
+			actor: "dave@acme",
+			action: "set_field",
+			fieldPath: "settlement.timeout",
+			oldValue: "12h",
+			newValue: "86400s",
+			configVersion: 6,
+			createdAt: new Date(Date.now() - 3 * 86_400_000).toISOString(),
+		},
+		{
+			// A rollback marker entry (no field path) → exercises the feed's rollback branch.
+			id: "e5",
+			actor: "alice@acme",
+			action: "rollback",
+			newValue: "v3",
+			configVersion: 5,
+			createdAt: new Date(Date.now() - 30_000).toISOString(),
+		},
+		{
+			// An actor-less, field-less, action-only entry → exercises the "?" initials
+			// fallback and the bare-action branch of the feed.
+			id: "e6",
+			action: "export",
+			createdAt: new Date(Date.now() - 10_000).toISOString(),
 		},
 	],
 };
@@ -133,5 +198,55 @@ describe("ReadView", () => {
 		expect(screen.getByText(/Not set — resolving to schema default/)).toBeInTheDocument();
 		// actor appears in the recent-changes feed
 		expect(screen.getAllByText(/carol@acme/).length).toBeGreaterThan(0);
+	});
+
+	it("renders JSON and duration values, and a days-ago provenance timestamp", () => {
+		render(<ReadView tenantId="t1" />);
+		// JSON value rendered in a <pre>.
+		const overrides = screen.getByTestId("value-api.overrides");
+		expect(within(overrides).getByText('{"flag":true}')).toBeInTheDocument();
+		// Duration value humanised (86400s → 24h).
+		const timeout = screen.getByTestId("value-settlement.timeout");
+		expect(within(timeout).getByText("24h")).toBeInTheDocument();
+		// 3-days-old change → "3d ago" in the provenance line.
+		expect(within(timeout).getByText(/3d ago/)).toBeInTheDocument();
+	});
+
+	it("renders a rollback entry and a bare-action entry in the changes feed", () => {
+		render(<ReadView tenantId="t1" />);
+		// Rollback marker → "restored config to v3".
+		expect(screen.getByText(/restored config to/)).toBeInTheDocument();
+		expect(screen.getAllByText("v3").length).toBeGreaterThan(0);
+		// Actor-less entry → "?" initials fallback + bare action label.
+		expect(screen.getAllByText("export").length).toBeGreaterThan(0);
+		expect(screen.getAllByText("?").length).toBeGreaterThan(0);
+	});
+
+	it("toggles the deprecated fields in and out of view", () => {
+		render(<ReadView tenantId="t1" />);
+		// Deprecated fields are hidden by default.
+		expect(screen.queryByTestId("value-flags.legacy_mode")).toBeNull();
+		fireEvent.click(screen.getByRole("button", { name: /show deprecated/ }));
+		expect(screen.getByTestId("value-flags.legacy_mode")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: /hide deprecated/ }));
+		expect(screen.queryByTestId("value-flags.legacy_mode")).toBeNull();
+	});
+
+	it("distinguishes explicit-null from unset by provenance", () => {
+		render(<ReadView tenantId="t1" />);
+
+		// settlement.window was deliberately cleared → explicit null (a stored value).
+		const cleared = screen.getByTestId("value-settlement.window");
+		expect(within(cleared).getByTestId("null-badge-settlement.window")).toHaveTextContent("null");
+		expect(within(cleared).getByText(/overrides the schema default/)).toBeInTheDocument();
+		// Right rail reads it as a deliberate clear, with the clearing actor.
+		expect(within(cleared).getByText(/set · null · v7/)).toBeInTheDocument();
+		expect(within(cleared).getByText(/cleared by bob@acme/)).toBeInTheDocument();
+
+		// settlement.cutoff_time was never set → unset (default applies), no null badge.
+		const unset = screen.getByTestId("value-settlement.cutoff_time");
+		expect(within(unset).queryByTestId("null-badge-settlement.cutoff_time")).toBeNull();
+		expect(within(unset).getByText(/Not set — resolving to schema default/)).toBeInTheDocument();
+		expect(within(unset).getByText(/provenance: default/)).toBeInTheDocument();
 	});
 });

--- a/src/components/ChainBreakPanel.tsx
+++ b/src/components/ChainBreakPanel.tsx
@@ -1,0 +1,178 @@
+/**
+ * Broken-chain (tamper-detected) panel — the alarming inverse of the "chain
+ * active" trust badge.
+ *
+ * API REALITY: the decree server maintains a SHA-256-linked, per-tenant audit
+ * chain, but the REST gateway exposes **no** chain-verification RPC, and the
+ * audit-entry model carries **no** hash fields. There is no `VerifyChain`
+ * operation and no `v1AuditChainBreak` model in the generated schema. So this is
+ * built to the *documented* shape from a typed local model — it does NOT invent
+ * an endpoint or fake a fetch. When no break is supplied (the steady state until
+ * the gateway exposes `VerifyChain`), it degrades to a clearly-marked
+ * pending-server note. It activates unchanged once a real break flows in.
+ *
+ * Shape mirrors the audit-service proto's `AuditChainBreak`:
+ *
+ *   VerifyChainResponse { tenant_id, total, ok, breaks[] }
+ *   AuditChainBreak     { entry_id, position (0-based), got, want }
+ *
+ *   - `got`  = the `entry_hash` STORED on the entry
+ *   - `want` = the hash RECOMPUTED (SHA-256) from the entry's fields
+ *   - break  = `got != want`
+ */
+
+/**
+ * One chain break, exactly matching the audit-service `AuditChainBreak` message.
+ * `position` is 0-based. Typed locally because the gateway does not (yet) expose
+ * the model; the field names are kept identical so wiring to the real response is
+ * a one-line swap once `VerifyChain` lands.
+ */
+export interface AuditChainBreak {
+	/** The id of the entry whose stored hash no longer matches the recomputed one. */
+	entryId: string;
+	/** 0-based index of the breaking entry within the tenant's chain. */
+	position: number;
+	/** The `entry_hash` stored on the entry in the DB. */
+	got: string;
+	/** The SHA-256 recomputed from the entry's fields. break = got != want. */
+	want: string;
+	/** Optional context surfaced from the entry, if available. */
+	actor?: string;
+	/** Optional action label surfaced from the entry, if available. */
+	action?: string;
+}
+
+/** Total entries walked + how many verified, for the summary line (optional). */
+export interface ChainVerification {
+	/** Total entries in the chain (proto: `total`). */
+	total?: number;
+	/** Whether the whole chain verified (proto: `ok`). */
+	ok?: boolean;
+	/** The breaks found (proto: `breaks[]`). Empty/undefined → chain intact. */
+	breaks?: AuditChainBreak[];
+}
+
+/** Shorten a hash for display while keeping head + tail recognisable. */
+function shortHash(hash: string): string {
+	if (hash.length <= 12) return hash;
+	return `${hash.slice(0, 4)}…${hash.slice(-3)}`;
+}
+
+/**
+ * Render the broken-chain detail for the *first* break (the chain is untrusted
+ * from the first mismatch on). The proto returns `breaks[]` — a list — so this
+ * also notes when there is more than one.
+ */
+export function ChainBreakPanel({ verification }: { verification?: ChainVerification }) {
+	const breaks = verification?.breaks ?? [];
+	const firstBreak = breaks[0];
+
+	// Degrade gracefully: no break data means either the chain is intact or — the
+	// real case today — the gateway does not expose VerifyChain yet. Either way,
+	// render an honest pending-server note, never a fake result.
+	if (!firstBreak) {
+		return (
+			<div
+				data-testid="chain-break-pending"
+				className="border-t border-line bg-surface-2 px-4 py-2.5 text-[11.5px] text-fg-2"
+			>
+				Independent chain re-verification (<code className="font-mono text-fg">VerifyChain</code>)
+				is not yet exposed by the REST gateway. When it lands, a tampered entry surfaces here with
+				its stored vs. recomputed hash.
+			</div>
+		);
+	}
+
+	const total = verification?.total;
+	return (
+		<div data-testid="chain-break-panel" className="border-t border-line">
+			<div className="flex flex-wrap items-center gap-2.5 px-4 pt-3.5 pb-1">
+				<span
+					data-testid="chain-break-badge"
+					className="inline-flex items-center gap-1.5 rounded-full border border-[color-mix(in_oklch,var(--danger)_45%,transparent)] bg-danger-soft px-2.5 py-0.5 font-mono text-[11px] font-semibold text-danger"
+				>
+					<svg
+						aria-hidden="true"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2.2"
+						className="h-3.5 w-3.5"
+					>
+						<path d="M12 3l8 4v5c0 5-3.5 7.5-8 9-4.5-1.5-8-4-8-9V7z" />
+						<path d="M9 9l6 6M15 9l-6 6" />
+					</svg>
+					chain BROKEN
+				</span>
+				<span className="font-mono text-[11px] text-fg-3">
+					{total !== undefined ? (
+						<>
+							first mismatch at position <b className="text-fg">{firstBreak.position}</b> of {total}
+						</>
+					) : (
+						<>
+							first mismatch at position <b className="text-fg">{firstBreak.position}</b>
+						</>
+					)}
+					{breaks.length > 1 && <> · {breaks.length} breaks total</>}
+				</span>
+			</div>
+
+			<dl className="px-4 py-2 font-mono text-[11.5px]">
+				<HashRow label="entry_id · position">
+					<span className="text-fg-2">
+						{firstBreak.entryId} · <b className="text-fg">position {firstBreak.position}</b>{" "}
+						<span className="text-fg-3">(0-based)</span>
+					</span>
+				</HashRow>
+				{firstBreak.actor && (
+					<HashRow label="actor · action">
+						<span className="text-fg-2">
+							{firstBreak.actor}
+							{firstBreak.action ? ` · ${firstBreak.action}` : ""}
+						</span>
+					</HashRow>
+				)}
+				<HashRow label="got (entry_hash)">
+					<span data-testid="chain-break-got" className="text-danger">
+						{shortHash(firstBreak.got)} <span className="text-fg-3">— stored on the entry</span>
+					</span>
+				</HashRow>
+				<HashRow label="want (recomputed)">
+					<span data-testid="chain-break-want" className="text-warn">
+						{shortHash(firstBreak.want)} <span className="text-fg-3">— SHA-256 of entry</span>
+					</span>
+				</HashRow>
+			</dl>
+
+			<div className="flex items-start gap-2 border-t border-line bg-danger-soft px-4 py-2.5 text-[11.5px] text-fg-2">
+				<svg
+					aria-hidden="true"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="2"
+					className="mt-0.5 h-3.5 w-3.5 flex-none text-danger"
+				>
+					<path d="M12 9v4m0 4h.01M10.3 3.9 2.4 18a2 2 0 0 0 1.7 3h15.8a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z" />
+				</svg>
+				<span>
+					At <b className="text-fg">position {firstBreak.position}</b> the stored{" "}
+					<code className="font-mono text-fg">got</code> hash ≠ the recomputed{" "}
+					<code className="font-mono text-fg">want</code> — the audit log was{" "}
+					<b className="text-fg">tampered or corrupted</b> here. Everything from this entry on is
+					untrusted until investigated.
+				</span>
+			</div>
+		</div>
+	);
+}
+
+function HashRow({ label, children }: { label: string; children: React.ReactNode }) {
+	return (
+		<div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-0.5 border-t border-line py-1.5 first:border-t-0">
+			<dt className="text-fg-3">{label}</dt>
+			<dd className="min-w-0 text-right">{children}</dd>
+		</div>
+	);
+}

--- a/src/components/ConflictResolver.tsx
+++ b/src/components/ConflictResolver.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import type { components } from "../api/schema";
+import { RedactedValue } from "./FieldBadges";
 
 type SchemaField = components["schemas"]["v1SchemaField"];
 
@@ -56,6 +57,8 @@ export function ConflictResolver({
 	const [choices, setChoices] = useState<Map<string, Resolution>>(
 		() => new Map(conflicts.map((c) => [c.path, "mine"])),
 	);
+	// Which fields have their side-by-side compare pane expanded.
+	const [compared, setCompared] = useState<Set<string>>(() => new Set());
 
 	// Re-seed when the conflict set changes (a fresh rejection opens the panel anew).
 	const conflictKey = useMemo(() => conflicts.map((c) => c.path).join("|"), [conflicts]);
@@ -63,6 +66,7 @@ export function ConflictResolver({
 	if (conflictKey !== seededKey) {
 		setSeededKey(conflictKey);
 		setChoices(new Map(conflicts.map((c) => [c.path, "mine"])));
+		setCompared(new Set());
 	}
 
 	if (!open) return null;
@@ -71,6 +75,15 @@ export function ConflictResolver({
 		setChoices((prev) => {
 			const next = new Map(prev);
 			next.set(path, res);
+			return next;
+		});
+	};
+
+	const toggleCompare = (path: string) => {
+		setCompared((prev) => {
+			const next = new Set(prev);
+			if (next.has(path)) next.delete(path);
+			else next.add(path);
 			return next;
 		});
 	};
@@ -125,6 +138,10 @@ export function ConflictResolver({
 				<div className="min-h-0 flex-1 space-y-3 overflow-y-auto px-5 py-4">
 					{conflicts.map((c) => {
 						const choice = choices.get(c.path) ?? "mine";
+						const isComparing = compared.has(c.path);
+						// Sensitive (write-only) values are hard-redacted on every read path;
+						// never surface the staged or committed cleartext in the resolver.
+						const sensitive = c.field.sensitive === true;
 						return (
 							<div
 								key={c.path}
@@ -134,6 +151,35 @@ export function ConflictResolver({
 								<div className="mb-2 flex flex-wrap items-center gap-2">
 									<span className="text-sm font-medium text-fg">{c.field.title ?? c.path}</span>
 									<code className="font-mono text-xs text-fg-3">{c.path}</code>
+									{sensitive && (
+										<span className="rounded-[var(--r-xs)] border border-line-2 bg-surface px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-fg-2">
+											sensitive
+										</span>
+									)}
+									<button
+										type="button"
+										onClick={() => toggleCompare(c.path)}
+										aria-pressed={isComparing}
+										aria-controls={`compare-${c.path}`}
+										data-testid={`conflict-compare-toggle-${c.path}`}
+										className={`ml-auto inline-flex items-center gap-1.5 rounded-[var(--r-xs)] border px-2 py-0.5 font-mono text-[11px] ${
+											isComparing
+												? "border-accent-line bg-accent-soft text-accent"
+												: "border-line-2 bg-surface text-fg-2 hover:bg-surface-3"
+										}`}
+									>
+										<svg
+											aria-hidden="true"
+											viewBox="0 0 24 24"
+											fill="none"
+											stroke="currentColor"
+											strokeWidth="2"
+											className="h-3 w-3"
+										>
+											<path d="M8 3v18M16 3v18M3 8h5M16 16h5" />
+										</svg>
+										Compare
+									</button>
 								</div>
 								<div className="grid gap-2 sm:grid-cols-2">
 									<ChoiceCard
@@ -141,6 +187,7 @@ export function ConflictResolver({
 										sub={freshVersion !== undefined ? `committed · v${freshVersion}` : "committed"}
 										value={c.theirs}
 										tone="theirs"
+										sensitive={sensitive}
 										selected={choice === "theirs"}
 										onSelect={() => pick(c.path, "theirs")}
 									/>
@@ -149,10 +196,20 @@ export function ConflictResolver({
 										sub="your staged edit"
 										value={c.mine}
 										tone="mine"
+										sensitive={sensitive}
 										selected={choice === "mine"}
 										onSelect={() => pick(c.path, "mine")}
 									/>
 								</div>
+								{isComparing && (
+									<CompareView
+										path={c.path}
+										theirs={c.theirs}
+										mine={c.mine}
+										freshVersion={freshVersion}
+										sensitive={sensitive}
+									/>
+								)}
 							</div>
 						);
 					})}
@@ -200,6 +257,7 @@ function ChoiceCard({
 	sub,
 	value,
 	tone,
+	sensitive,
 	selected,
 	onSelect,
 }: {
@@ -207,6 +265,7 @@ function ChoiceCard({
 	sub: string;
 	value: string;
 	tone: "mine" | "theirs";
+	sensitive: boolean;
 	selected: boolean;
 	onSelect: () => void;
 }) {
@@ -233,9 +292,93 @@ function ChoiceCard({
 				{label}
 				<span className="font-mono text-[10px] text-fg-3">· {sub}</span>
 			</span>
-			<code className="block max-h-24 overflow-auto break-all font-mono text-xs text-fg">
-				{value === "" ? "(empty)" : value}
-			</code>
+			{sensitive ? (
+				<span className="block">
+					<RedactedValue />
+				</span>
+			) : (
+				<code className="block max-h-24 overflow-auto break-all font-mono text-xs text-fg">
+					{value === "" ? "(empty)" : value}
+				</code>
+			)}
 		</button>
+	);
+}
+
+/**
+ * Side-by-side compare pane (the third arm of the three-way resolver). Shows the
+ * committed "theirs" value flowing into the staged "mine" value — the exact diff
+ * a "keep mine → rebase" would re-apply against the fresh checksum. Sensitive
+ * (write-only) values stay `[REDACTED]` on both sides; the cleartext is never
+ * surfaced in any state.
+ */
+function CompareView({
+	path,
+	theirs,
+	mine,
+	freshVersion,
+	sensitive,
+}: {
+	path: string;
+	theirs: string;
+	mine: string;
+	freshVersion: number | undefined;
+	sensitive: boolean;
+}) {
+	return (
+		<div
+			id={`compare-${path}`}
+			data-testid={`conflict-compare-${path}`}
+			className="mt-3 grid grid-cols-[1fr_auto_1fr] items-stretch gap-2 rounded-[var(--r-sm)] border border-line bg-surface p-2.5"
+		>
+			<CompareSide
+				tag={freshVersion !== undefined ? `theirs · v${freshVersion}` : "theirs"}
+				value={theirs}
+				tone="theirs"
+				sensitive={sensitive}
+			/>
+			<span className="flex items-center text-fg-3">
+				<svg
+					aria-hidden="true"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="2"
+					className="h-4 w-4"
+				>
+					<path d="M5 12h14M13 6l6 6-6 6" />
+				</svg>
+			</span>
+			<CompareSide tag="mine" value={mine} tone="mine" sensitive={sensitive} />
+		</div>
+	);
+}
+
+function CompareSide({
+	tag,
+	value,
+	tone,
+	sensitive,
+}: {
+	tag: string;
+	value: string;
+	tone: "mine" | "theirs";
+	sensitive: boolean;
+}) {
+	const box = tone === "mine" ? "border-accent-line bg-accent-soft" : "border-line bg-surface-2";
+	return (
+		<div
+			data-testid={`compare-side-${tone}`}
+			className={`flex min-w-0 flex-col gap-1 rounded-[var(--r-xs)] border px-2 py-1.5 ${box}`}
+		>
+			<span className="font-mono text-[9px] uppercase tracking-wide text-fg-3">{tag}</span>
+			{sensitive ? (
+				<RedactedValue />
+			) : (
+				<code className="block max-h-24 overflow-auto break-all font-mono text-xs text-fg">
+					{value === "" ? "(empty)" : value}
+				</code>
+			)}
+		</div>
 	);
 }

--- a/src/components/__tests__/ChainBreakPanel.test.tsx
+++ b/src/components/__tests__/ChainBreakPanel.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { type AuditChainBreak, ChainBreakPanel, type ChainVerification } from "../ChainBreakPanel";
+
+const aBreak: AuditChainBreak = {
+	entryId: "a3f2-84",
+	position: 83,
+	got: "0a44aaaaaaaaaaaab02",
+	want: "9f3abbbbbbbbbbbbe21",
+	actor: "dave@acme",
+	action: "set_field payments.fee_rate",
+};
+
+describe("ChainBreakPanel — pending (no gateway support / chain intact)", () => {
+	it("degrades to a pending-server note when no verification is supplied", () => {
+		render(<ChainBreakPanel />);
+		const pending = screen.getByTestId("chain-break-pending");
+		expect(pending).toHaveTextContent(/not yet exposed by the REST gateway/);
+		expect(pending).toHaveTextContent(/VerifyChain/);
+		expect(screen.queryByTestId("chain-break-panel")).toBeNull();
+	});
+
+	it("degrades to the pending note when the breaks list is empty (chain intact)", () => {
+		const verification: ChainVerification = { total: 128, ok: true, breaks: [] };
+		render(<ChainBreakPanel verification={verification} />);
+		expect(screen.getByTestId("chain-break-pending")).toBeInTheDocument();
+		expect(screen.queryByTestId("chain-break-badge")).toBeNull();
+	});
+});
+
+describe("ChainBreakPanel — broken chain (AuditChainBreak shape)", () => {
+	it("renders got = stored, want = recomputed, entry_id and 0-based position", () => {
+		const verification: ChainVerification = { total: 128, ok: false, breaks: [aBreak] };
+		render(<ChainBreakPanel verification={verification} />);
+		expect(screen.getByTestId("chain-break-panel")).toBeInTheDocument();
+		expect(screen.getByTestId("chain-break-badge")).toHaveTextContent(/chain BROKEN/);
+
+		// got = the stored entry hash; want = the recomputed SHA-256 (not inverted).
+		expect(screen.getByTestId("chain-break-got")).toHaveTextContent(/stored on the entry/);
+		expect(screen.getByTestId("chain-break-want")).toHaveTextContent(/SHA-256 of entry/);
+		// Short-hashed head…tail of each.
+		expect(screen.getByTestId("chain-break-got")).toHaveTextContent(/0a44…b02/);
+		expect(screen.getByTestId("chain-break-want")).toHaveTextContent(/9f3a…e21/);
+
+		// entry_id + the literal 0-based position.
+		const panel = screen.getByTestId("chain-break-panel");
+		expect(within(panel).getByText(/a3f2-84/)).toBeInTheDocument();
+		expect(within(panel).getAllByText(/position 83/).length).toBeGreaterThan(0);
+		expect(within(panel).getByText(/0-based/)).toBeInTheDocument();
+		// Total threaded into the summary line.
+		expect(within(panel).getByText(/of 128/)).toBeInTheDocument();
+	});
+
+	it("renders the optional actor · action row when present", () => {
+		render(<ChainBreakPanel verification={{ breaks: [aBreak] }} />);
+		const panel = screen.getByTestId("chain-break-panel");
+		expect(within(panel).getByText(/dave@acme/)).toBeInTheDocument();
+		expect(within(panel).getByText(/set_field payments\.fee_rate/)).toBeInTheDocument();
+	});
+
+	it("omits the actor row and the total when neither is supplied", () => {
+		const minimal: AuditChainBreak = { entryId: "x-1", position: 0, got: "aaaa", want: "bbbb" };
+		render(<ChainBreakPanel verification={{ breaks: [minimal] }} />);
+		const panel = screen.getByTestId("chain-break-panel");
+		// No actor → no "actor · action" label.
+		expect(within(panel).queryByText(/actor · action/)).toBeNull();
+		// No total → the summary omits the "of N" total suffix.
+		expect(within(panel).queryByText(/of \d/)).toBeNull();
+		// position 0 still renders (0-based).
+		expect(within(panel).getAllByText(/position 0/).length).toBeGreaterThan(0);
+	});
+
+	it("does not shorten a hash that is already short", () => {
+		const shortBreak: AuditChainBreak = { entryId: "x", position: 1, got: "abc", want: "def" };
+		render(<ChainBreakPanel verification={{ breaks: [shortBreak] }} />);
+		expect(screen.getByTestId("chain-break-got")).toHaveTextContent(/abc/);
+		expect(screen.getByTestId("chain-break-want")).toHaveTextContent(/def/);
+	});
+
+	it("notes when there is more than one break (the proto returns a list)", () => {
+		const second: AuditChainBreak = { entryId: "b-2", position: 90, got: "1111", want: "2222" };
+		render(<ChainBreakPanel verification={{ total: 128, breaks: [aBreak, second] }} />);
+		expect(screen.getByText(/2 breaks total/)).toBeInTheDocument();
+		// Only the first break's detail is rendered (chain untrusted from there on).
+		expect(screen.getByTestId("chain-break-got")).toHaveTextContent(/0a44…b02/);
+		expect(screen.queryByText(/1111/)).toBeNull();
+	});
+});

--- a/src/components/__tests__/ConflictResolver.test.tsx
+++ b/src/components/__tests__/ConflictResolver.test.tsx
@@ -179,6 +179,93 @@ describe("ConflictResolver — actions", () => {
 	});
 });
 
+describe("ConflictResolver — compare view (the third arm)", () => {
+	it("hides the compare pane by default and reveals it on toggle", () => {
+		renderResolver();
+		const feeRow = screen.getByTestId("conflict-payments.fee_rate");
+		expect(within(feeRow).queryByTestId("conflict-compare-payments.fee_rate")).toBeNull();
+
+		const toggle = within(feeRow).getByTestId("conflict-compare-toggle-payments.fee_rate");
+		expect(toggle).toHaveAttribute("aria-pressed", "false");
+		fireEvent.click(toggle);
+
+		const pane = within(feeRow).getByTestId("conflict-compare-payments.fee_rate");
+		expect(pane).toBeInTheDocument();
+		expect(toggle).toHaveAttribute("aria-pressed", "true");
+		// Side-by-side: theirs (committed) flows into mine (staged).
+		expect(within(within(pane).getByTestId("compare-side-theirs")).getByText("3")).toBeTruthy();
+		expect(within(within(pane).getByTestId("compare-side-mine")).getByText("2.5")).toBeTruthy();
+	});
+
+	it("collapses the compare pane on a second toggle", () => {
+		renderResolver();
+		const feeRow = screen.getByTestId("conflict-payments.fee_rate");
+		const toggle = within(feeRow).getByTestId("conflict-compare-toggle-payments.fee_rate");
+		fireEvent.click(toggle);
+		expect(within(feeRow).getByTestId("conflict-compare-payments.fee_rate")).toBeInTheDocument();
+		fireEvent.click(toggle);
+		expect(within(feeRow).queryByTestId("conflict-compare-payments.fee_rate")).toBeNull();
+	});
+
+	it("renders an empty committed value as (empty) in the compare pane", () => {
+		renderResolver();
+		const retriesRow = screen.getByTestId("conflict-payments.retries");
+		fireEvent.click(within(retriesRow).getByTestId("conflict-compare-toggle-payments.retries"));
+		const pane = within(retriesRow).getByTestId("conflict-compare-payments.retries");
+		// theirs is "" for retries → the theirs side shows (empty).
+		expect(
+			within(within(pane).getByTestId("compare-side-theirs")).getByText("(empty)"),
+		).toBeTruthy();
+	});
+
+	it("compare toggle works independently per field", () => {
+		renderResolver();
+		const feeRow = screen.getByTestId("conflict-payments.fee_rate");
+		fireEvent.click(within(feeRow).getByTestId("conflict-compare-toggle-payments.fee_rate"));
+		// fee compare open, retries compare still closed.
+		expect(within(feeRow).getByTestId("conflict-compare-payments.fee_rate")).toBeInTheDocument();
+		const retriesRow = screen.getByTestId("conflict-payments.retries");
+		expect(within(retriesRow).queryByTestId("conflict-compare-payments.retries")).toBeNull();
+	});
+});
+
+describe("ConflictResolver — sensitive values stay redacted", () => {
+	const sensitiveConflict: FieldConflict[] = [
+		{
+			path: "api.secret",
+			field: {
+				path: "api.secret",
+				title: "API Secret",
+				type: "FIELD_TYPE_STRING",
+				sensitive: true,
+			},
+			mine: "new-super-secret",
+			theirs: "their-secret",
+			freshChecksum: "ff00",
+		},
+	];
+
+	it("never reveals the staged or committed cleartext in the choice cards", () => {
+		renderResolver({ conflicts: sensitiveConflict });
+		const row = screen.getByTestId("conflict-api.secret");
+		expect(within(row).getByText("sensitive")).toBeInTheDocument();
+		// Both choice cards render [REDACTED]; the cleartext is absent.
+		expect(within(row).getAllByText("[REDACTED]").length).toBeGreaterThanOrEqual(2);
+		expect(within(row).queryByText("new-super-secret")).toBeNull();
+		expect(within(row).queryByText("their-secret")).toBeNull();
+	});
+
+	it("keeps both compare sides redacted when comparing a sensitive field", () => {
+		renderResolver({ conflicts: sensitiveConflict });
+		const row = screen.getByTestId("conflict-api.secret");
+		fireEvent.click(within(row).getByTestId("conflict-compare-toggle-api.secret"));
+		const pane = within(row).getByTestId("conflict-compare-api.secret");
+		expect(within(pane).getAllByText("[REDACTED]").length).toBe(2);
+		expect(within(pane).queryByText("new-super-secret")).toBeNull();
+		expect(within(pane).queryByText("their-secret")).toBeNull();
+	});
+});
+
 describe("ConflictResolver — re-seeding on a new conflict set", () => {
 	it("resets choices to 'mine' when the conflict set changes", () => {
 		const { rerender } = renderResolver();

--- a/src/lib/__tests__/provenance.test.ts
+++ b/src/lib/__tests__/provenance.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import type { components } from "../../api/schema";
+import { latestEntryForField, resolveFieldProvenance } from "../provenance";
+
+type AuditEntry = components["schemas"]["v1AuditEntry"];
+
+describe("resolveFieldProvenance — set fields", () => {
+	it("classifies a field that holds a value as 'set', carrying latest provenance", () => {
+		const entries: AuditEntry[] = [
+			{
+				fieldPath: "payments.fee_rate",
+				oldValue: "1.0",
+				newValue: "2.5",
+				actor: "carol@acme",
+				createdAt: "2026-06-15T10:00:00Z",
+				configVersion: 7,
+			},
+		];
+		const p = resolveFieldProvenance("payments.fee_rate", true, entries);
+		expect(p.state).toBe("set");
+		expect(p.actor).toBe("carol@acme");
+		expect(p.version).toBe(7);
+		expect(p.time).toBe("2026-06-15T10:00:00Z");
+	});
+
+	it("is 'set' even with no audit history (value present, provenance unknown)", () => {
+		const p = resolveFieldProvenance("a.b", true, []);
+		expect(p.state).toBe("set");
+		expect(p.actor).toBeUndefined();
+		expect(p.version).toBeUndefined();
+	});
+});
+
+describe("resolveFieldProvenance — explicit null vs unset", () => {
+	it("classifies a never-set field (no entries) as 'unset' → default applies", () => {
+		const p = resolveFieldProvenance("settlement.cutoff_time", false, []);
+		expect(p.state).toBe("unset");
+		// Unset carries no provenance — it resolves to the schema default.
+		expect(p.actor).toBeUndefined();
+		expect(p.version).toBeUndefined();
+	});
+
+	it("classifies a deliberate clear (had old, empty new) as 'explicit-null'", () => {
+		const entries: AuditEntry[] = [
+			{
+				fieldPath: "settlement.cutoff_time",
+				oldValue: "2025-01-15T09:30:00Z",
+				newValue: "",
+				actor: "bob@acme",
+				configVersion: 7,
+			},
+		];
+		const p = resolveFieldProvenance("settlement.cutoff_time", false, entries);
+		expect(p.state).toBe("explicit-null");
+		expect(p.actor).toBe("bob@acme");
+		expect(p.version).toBe(7);
+	});
+
+	it("treats a missing (undefined) new value with a prior value as a clear", () => {
+		const entries: AuditEntry[] = [
+			{ fieldPath: "f", oldValue: "x", actor: "a@b", configVersion: 3 },
+		];
+		expect(resolveFieldProvenance("f", false, entries).state).toBe("explicit-null");
+	});
+
+	it("honours an explicit clear/unset action name even without an old value", () => {
+		const cleared: AuditEntry[] = [{ fieldPath: "f", action: "clear_field", actor: "a@b" }];
+		expect(resolveFieldProvenance("f", false, cleared).state).toBe("explicit-null");
+		const unset: AuditEntry[] = [{ fieldPath: "f", action: "unset_field", actor: "a@b" }];
+		expect(resolveFieldProvenance("f", false, unset).state).toBe("explicit-null");
+	});
+
+	it("does NOT treat an add (no old, has new) as a clear when the value is now empty", () => {
+		// A field that was added (no prior value) and is currently empty with no
+		// clearing entry resolves to unset, not explicit-null.
+		const entries: AuditEntry[] = [
+			{ fieldPath: "f", newValue: "", actor: "a@b", configVersion: 2 },
+		];
+		expect(resolveFieldProvenance("f", false, entries).state).toBe("unset");
+	});
+});
+
+describe("latestEntryForField — ordering", () => {
+	it("returns the first matching entry in newest-first input order", () => {
+		const entries: AuditEntry[] = [
+			{ fieldPath: "f", newValue: "newest", configVersion: 9 },
+			{ fieldPath: "f", newValue: "older", configVersion: 5 },
+			{ fieldPath: "other", newValue: "x", configVersion: 99 },
+		];
+		expect(latestEntryForField(entries, "f")?.newValue).toBe("newest");
+	});
+
+	it("prefers the higher config version when entries are out of order", () => {
+		const entries: AuditEntry[] = [
+			{ fieldPath: "f", newValue: "older", configVersion: 5 },
+			{ fieldPath: "f", newValue: "newest", configVersion: 9 },
+		];
+		expect(latestEntryForField(entries, "f")?.newValue).toBe("newest");
+	});
+
+	it("returns undefined when no entry matches the field path", () => {
+		expect(latestEntryForField([{ fieldPath: "x" }], "f")).toBeUndefined();
+	});
+});

--- a/src/lib/provenance.ts
+++ b/src/lib/provenance.ts
@@ -1,0 +1,97 @@
+/**
+ * Provenance resolution for a field's *empty* read state.
+ *
+ * A nullable field has two distinct empty states the UI must not conflate:
+ *
+ *  - **unset** — no per-tenant value was ever written, so the schema default
+ *    resolves. There is no audit entry that set (or cleared) the field.
+ *  - **explicit null** — the field was deliberately written to null, which
+ *    *overrides* the default. The most recent audit entry for the field cleared
+ *    it (an `old_value` existed, the `new_value` is empty/absent — or the action
+ *    is a clear), so a stored null is a value, not the absence of one.
+ *
+ * The REST gateway models neither a null member on `TypedValue` nor a provenance
+ * flag on `ConfigValue` (a cleared field simply isn't in `config.values`). The
+ * only signal that distinguishes "cleared" from "never set" is the audit log, the
+ * same per-field delta source the read view already walks for provenance. This
+ * keeps the derivation pure and unit-testable.
+ */
+
+import type { components } from "../api/schema";
+
+type AuditEntry = components["schemas"]["v1AuditEntry"];
+
+/** The resolved state of a field that currently holds no value. */
+export type EmptyProvenance = "explicit-null" | "unset";
+
+/** The classified read state of a field, plus the provenance metadata behind it. */
+export interface FieldProvenance {
+	/** "set" when the field holds a value; otherwise how the empty resolves. */
+	state: "set" | EmptyProvenance;
+	/** Actor of the most recent change to this field, if any. */
+	actor?: string;
+	/** Timestamp of the most recent change to this field, if any. */
+	time?: string;
+	/** Config version of the most recent change to this field, if any. */
+	version?: number;
+}
+
+/** Whether an audit entry represents a clear (a deliberate write of null). */
+function isClearEntry(entry: AuditEntry): boolean {
+	// A set_field whose new value is empty/absent but which had a prior value is a
+	// clear. An explicit "clear"/"unset" action name is also honoured if present.
+	const action = (entry.action ?? "").toLowerCase();
+	if (action.includes("clear") || action.includes("unset")) return true;
+	if (entry.fieldPath === undefined) return false;
+	const hadOld = entry.oldValue !== undefined && entry.oldValue !== "";
+	const hasNew = entry.newValue !== undefined && entry.newValue !== "";
+	return hadOld && !hasNew;
+}
+
+/**
+ * Find the most recent audit entry for a field path. Entries are assumed to be in
+ * the gateway's newest-first order (the order `useAuditLog` returns), so the first
+ * match wins; we fall back to the highest `config_version` when ordering is mixed.
+ */
+export function latestEntryForField(
+	entries: AuditEntry[],
+	fieldPath: string,
+): AuditEntry | undefined {
+	let best: AuditEntry | undefined;
+	for (const e of entries) {
+		if (e.fieldPath !== fieldPath) continue;
+		if (best === undefined) {
+			best = e;
+			continue;
+		}
+		// Prefer a higher config version when both carry one (defends against a
+		// caller passing un-sorted entries); otherwise keep the first seen.
+		if ((e.configVersion ?? -1) > (best.configVersion ?? -1)) best = e;
+	}
+	return best;
+}
+
+/**
+ * Resolve a field's read state from its current value presence and the audit log.
+ *
+ * @param fieldPath   the dot-path being resolved
+ * @param hasValue    whether `config.values` currently carries a value for it
+ * @param entries     audit entries (newest-first preferred; mixed order tolerated)
+ */
+export function resolveFieldProvenance(
+	fieldPath: string,
+	hasValue: boolean,
+	entries: AuditEntry[],
+): FieldProvenance {
+	const latest = latestEntryForField(entries, fieldPath);
+	const meta = latest
+		? { actor: latest.actor, time: latest.createdAt, version: latest.configVersion }
+		: {};
+
+	if (hasValue) return { state: "set", ...meta };
+
+	// No current value: an explicit clear in the audit log means a stored null
+	// (overrides the default); otherwise the field was never set (default applies).
+	if (latest && isClearEntry(latest)) return { state: "explicit-null", ...meta };
+	return { state: "unset" };
+}

--- a/src/pages/ReadView.tsx
+++ b/src/pages/ReadView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { components } from "../api/schema";
 import {
 	DeprecatedBadge,
@@ -10,16 +10,11 @@ import { SkeletonDetail } from "../components/Skeleton";
 import { fieldTypeColor, fieldTypeIcon, fieldTypeLabel } from "../lib/field-types";
 import { formatDuration, groupFields, typedValueToString } from "../lib/fields";
 import { useAuditLog, useConfig, useSchemaVersion, useTenant } from "../lib/hooks";
+import { type FieldProvenance, resolveFieldProvenance } from "../lib/provenance";
 
 type SchemaField = components["schemas"]["v1SchemaField"];
 type FieldType = components["schemas"]["v1FieldType"];
 type AuditEntry = components["schemas"]["v1AuditEntry"];
-
-interface Provenance {
-	actor: string;
-	time: string;
-	version?: number;
-}
 
 /** Initials for an actor avatar — first two letters of the local part ("carol@acme" → "CA"). */
 function initials(actor: string): string {
@@ -81,20 +76,13 @@ export function ReadView({ tenantId }: { tenantId: string }) {
 		return m;
 	}, [config]);
 
-	// Newest-first audit entries → most-recent change per field (provenance).
-	const provenanceMap = useMemo(() => {
-		const m = new Map<string, Provenance>();
-		for (const e of entries) {
-			if (e.fieldPath && !m.has(e.fieldPath)) {
-				m.set(e.fieldPath, {
-					actor: e.actor ?? "",
-					time: e.createdAt ?? "",
-					version: e.configVersion,
-				});
-			}
-		}
-		return m;
-	}, [entries]);
+	// Per-field provenance: classifies each field as set / explicit-null / unset
+	// from its value presence + the audit log (the only source that distinguishes a
+	// deliberate clear from a never-set field). Computed per field in the row.
+	const provenanceFor = useCallback(
+		(path: string): FieldProvenance => resolveFieldProvenance(path, valueMap.has(path), entries),
+		[valueMap, entries],
+	);
 
 	const groups = useMemo(() => groupFields(fields), [fields]);
 	const setCount = fields.filter((f) => valueMap.has(f.path ?? "")).length;
@@ -180,7 +168,7 @@ export function ReadView({ tenantId }: { tenantId: string }) {
 												field={field}
 												value={valueMap.get(field.path ?? "")}
 												checksum={checksumMap.get(field.path ?? "")}
-												provenance={provenanceMap.get(field.path ?? "")}
+												provenance={provenanceFor(field.path ?? "")}
 											/>
 										))}
 									</div>
@@ -221,11 +209,13 @@ function ValueRow({
 	field: SchemaField;
 	value: string | undefined;
 	checksum: string | undefined;
-	provenance: Provenance | undefined;
+	provenance: FieldProvenance;
 }) {
-	const isSet = value !== undefined;
+	const isSet = provenance.state === "set";
+	const isExplicitNull = provenance.state === "explicit-null";
 	return (
 		<div
+			data-testid={`value-${field.path}`}
 			className={`grid grid-cols-[2.25rem_1fr_auto] gap-3 rounded-[var(--r-md)] border border-line bg-surface p-3 ${
 				field.deprecated ? "opacity-70" : ""
 			}`}
@@ -250,10 +240,25 @@ function ValueRow({
 					{field.readOnly && <ReadOnlyBadge />}
 					{field.sensitive && <SensitiveBadge />}
 					{field.deprecated && <DeprecatedBadge />}
-					{!isSet && (
-						<span className="rounded border border-dashed border-line px-1.5 py-0.5 text-xs text-fg-3">
-							unset
+					{field.nullable && !isSet && (
+						<span className="rounded border border-dashed border-line px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-fg-3">
+							nullable
 						</span>
+					)}
+					{/* Explicit null and unset read differently — a stored null is a value. */}
+					{isExplicitNull ? (
+						<span
+							data-testid={`null-badge-${field.path}`}
+							className="rounded border border-dashed border-warn/40 bg-warn-soft px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-warn"
+						>
+							null
+						</span>
+					) : (
+						!isSet && (
+							<span className="rounded border border-dashed border-line px-1.5 py-0.5 text-xs text-fg-3">
+								unset
+							</span>
+						)
 					)}
 				</div>
 				{field.description && <p className="mt-1 text-xs text-fg-2">{field.description}</p>}
@@ -263,20 +268,34 @@ function ValueRow({
 					</p>
 				)}
 				<div className="mt-1.5">
-					<ReadValue value={value} fieldType={field.type} sensitive={field.sensitive} />
+					<ReadValue
+						value={value}
+						fieldType={field.type}
+						sensitive={field.sensitive}
+						explicitNull={isExplicitNull}
+					/>
 				</div>
 			</div>
 
 			<div className="text-right text-xs whitespace-nowrap text-fg-3">
 				{isSet ? (
 					<span className="text-ok">
-						set{provenance?.version ? ` · v${provenance.version}` : ""}
+						set{provenance.version ? ` · v${provenance.version}` : ""}
+					</span>
+				) : isExplicitNull ? (
+					// Provenance distinguishes a deliberate clear from "default".
+					<span className="text-warn">
+						set · null{provenance.version ? ` · v${provenance.version}` : ""}
 					</span>
 				) : (
 					<span>default</span>
 				)}
-				{provenance?.actor && (
+				{!isSet && !isExplicitNull && (
+					<div className="font-mono text-[10px] text-fg-3">provenance: default</div>
+				)}
+				{provenance.actor && (
 					<div className="text-fg-3">
+						{isExplicitNull ? "cleared by " : ""}
 						{provenance.actor}
 						{provenance.time && <> · {timeAgo(provenance.time)}</>}
 					</div>
@@ -291,10 +310,12 @@ function ReadValue({
 	value,
 	fieldType,
 	sensitive,
+	explicitNull,
 }: {
 	value: string | undefined;
 	fieldType?: FieldType;
 	sensitive?: boolean;
+	explicitNull?: boolean;
 }) {
 	// Sensitive = write-only. The server already returns the literal [REDACTED];
 	// render it as-is for every role — no reveal, no fake masking.
@@ -305,6 +326,16 @@ function ReadValue({
 				<span className="font-mono text-[11px] text-fg-3">
 					write-only · never returned by the API
 				</span>
+			</span>
+		);
+	}
+	// Explicit null overrides the schema default — read it as a stored null, not
+	// as "resolving to default" (the unset case below).
+	if (explicitNull) {
+		return (
+			<span className="text-sm text-fg-2">
+				<code className="font-mono">null</code>{" "}
+				<span className="text-fg-3 italic">— overrides the schema default</span>
 			</span>
 		);
 	}

--- a/src/pages/SystemOverview.tsx
+++ b/src/pages/SystemOverview.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import type { components } from "../api/schema";
+import { ChainBreakPanel, type ChainVerification } from "../components/ChainBreakPanel";
 import { SkeletonTable } from "../components/Skeleton";
 import { useAuditLog, useSchemas, useTenants, useUnusedFields } from "../lib/hooks";
 import { label } from "../lib/labels";
@@ -141,6 +142,9 @@ export function SystemOverview() {
 						chainSettled={governanceSettled}
 						tenants={tenants}
 						signals={signals}
+						// No VerifyChain RPC on the gateway yet → no break data to thread.
+						// The broken-chain panel renders its pending-server note.
+						chainVerification={undefined}
 					/>
 				</>
 			)}
@@ -490,12 +494,19 @@ function TrustGovernanceSection({
 	chainSettled,
 	tenants,
 	signals,
+	chainVerification,
 }: {
 	tenantCount: number;
 	auditEntries: number;
 	chainSettled: boolean;
 	tenants: Tenant[];
 	signals: Record<string, TenantSignal>;
+	/**
+	 * Optional chain-verification result. Undefined today: the REST gateway exposes
+	 * no `VerifyChain` RPC, so the broken-chain panel degrades to a pending note.
+	 * Threading a real `breaks[]` here activates the tamper panel unchanged.
+	 */
+	chainVerification?: ChainVerification;
 }) {
 	// Tenants with at least one unused field — the deprecation candidates.
 	const flagged = tenants
@@ -527,12 +538,13 @@ function TrustGovernanceSection({
 					<div className="flex items-center gap-2.5 border-t border-line px-4 py-2.5 font-mono text-[11px] text-fg-3">
 						<span>tamper-evident · SHA-256 linked · epoch 1</span>
 					</div>
-					{/* Honest limitation: the gateway can't independently re-verify yet. */}
-					<div className="border-t border-line bg-surface-2 px-4 py-2.5 text-[11.5px] text-fg-2">
-						The server maintains an append-only, SHA-256-linked audit chain per tenant. Independent
-						chain re-verification is not yet exposed by the REST gateway, so this panel reflects
-						chain <b className="text-fg">activity</b>, not a re-walk.
-					</div>
+					{/*
+					 * Broken-chain (tamper) detail. The gateway exposes no VerifyChain RPC
+					 * yet, so no verification data flows in and the panel degrades to an
+					 * honest pending-server note. It activates unchanged once VerifyChain
+					 * lands and a real `breaks[]` is threaded through `chainVerification`.
+					 */}
+					<ChainBreakPanel verification={chainVerification} />
 				</div>
 
 				{/* unused fields */}

--- a/src/pages/__tests__/SystemOverview.test.tsx
+++ b/src/pages/__tests__/SystemOverview.test.tsx
@@ -181,9 +181,14 @@ describe("SystemOverview", () => {
 	it("states the honest chain limitation + names the server follow-up signal", () => {
 		renderOverview();
 		expect(screen.getByText(/SHA-256 linked · epoch 1/)).toBeInTheDocument();
-		expect(
-			screen.getByText(/Independent chain re-verification is not yet exposed by the REST gateway/),
-		).toBeInTheDocument();
+		// The broken-chain panel degrades to a pending-server note (no VerifyChain
+		// RPC on the gateway). The note names the limitation and the follow-up RPC;
+		// it spans a <code> element, so match on the testid container's text.
+		const pending = screen.getByTestId("chain-break-pending");
+		expect(pending).toHaveTextContent(/not yet exposed by the REST gateway/);
+		expect(pending).toHaveTextContent(/VerifyChain/);
+		// No tamper detail is rendered when there is no break data.
+		expect(screen.queryByTestId("chain-break-panel")).toBeNull();
 	});
 
 	it("links flagged tenants to their usage page in the governance panel", () => {

--- a/src/pages/tenants/__tests__/ConfigEditor.test.tsx
+++ b/src/pages/tenants/__tests__/ConfigEditor.test.tsx
@@ -95,6 +95,21 @@ const fields: SchemaField[] = [
 		redirectTo: "flags.tier",
 		defaultValue: "off",
 	},
+	// Extra fields exercising the remaining constraint kinds inline.
+	{
+		path: "app.semver",
+		title: "Semver",
+		type: "FIELD_TYPE_STRING",
+		tags: ["general"],
+		constraints: { regex: "^\\d+\\.\\d+\\.\\d+$" },
+	},
+	{
+		path: "payments.ratio",
+		title: "Ratio",
+		type: "FIELD_TYPE_NUMBER",
+		tags: ["payments"],
+		constraints: { exclusiveMin: 0, exclusiveMax: 1 },
+	},
 ];
 
 const configValues = [
@@ -258,6 +273,51 @@ describe("ConfigEditor — live validation per type", () => {
 		expect(screen.queryByRole("alert")).toBeNull();
 		expect(screen.getByRole("button", { name: /Save batch/ })).toBeEnabled();
 	});
+
+	it("flags a number above max inline", () => {
+		renderEditor();
+		changeField("field-payments.fee_rate", "Fee Rate", "150");
+		expect(screen.getByRole("alert")).toHaveTextContent(/Above maximum — must be ≤ 100/);
+	});
+
+	it("flags a regex (pattern) mismatch inline", () => {
+		renderEditor();
+		const input = changeField("field-app.semver", "Semver", "0.3");
+		expect(input).toHaveAttribute("aria-invalid", "true");
+		expect(screen.getByRole("alert")).toHaveTextContent(/Does not match the required pattern/);
+	});
+
+	it("flags exclusive-bound violations inline (exclusiveMin / exclusiveMax)", () => {
+		renderEditor();
+		changeField("field-payments.ratio", "Ratio", "0");
+		expect(screen.getByRole("alert")).toHaveTextContent(/Must be greater than 0/);
+		changeField("field-payments.ratio", "Ratio", "1");
+		expect(screen.getByRole("alert")).toHaveTextContent(/Must be less than 1/);
+	});
+
+	it("flags an out-of-set enum value inline", () => {
+		renderEditor();
+		// flags.tier is an enum select; selecting the empty option clears it. Drive an
+		// invalid value through change to exercise the enum branch.
+		const select = within(screen.getByTestId("field-flags.tier")).getByLabelText("Tier");
+		fireEvent.change(select, { target: { value: "" } });
+		// Empty on a non-nullable field is the Required error (enum still non-null).
+		expect(screen.getByRole("alert")).toHaveTextContent(/Required/);
+	});
+
+	it("flags an invalid time (RFC 3339) inline", () => {
+		renderEditor();
+		changeField("field-flags.cutover", "Cutover", "not-a-date");
+		expect(screen.getByRole("alert")).toHaveTextContent(/Invalid timestamp/);
+	});
+
+	it("flags a required, non-nullable field cleared to empty inline", () => {
+		renderEditor();
+		// app.name has minLength:1 and is non-nullable → clearing it is Required.
+		const input = changeField("field-app.name", "Application Name", "");
+		expect(input).toHaveAttribute("aria-invalid", "true");
+		expect(screen.getByRole("alert")).toHaveTextContent(/Required/);
+	});
 });
 
 describe("ConfigEditor — fieldEditBlock gating", () => {
@@ -332,6 +392,25 @@ describe("ConfigEditor — save + optimistic concurrency", () => {
 		const conflictRow = within(dialog).getByTestId("conflict-payments.fee_rate");
 		expect(within(conflictRow).getByText("2.5")).toBeInTheDocument(); // mine
 		expect(within(conflictRow).getByText("3")).toBeInTheDocument(); // theirs
+	});
+
+	it("opens the side-by-side compare view for a conflicting field", async () => {
+		mockClient.POST.mockResolvedValueOnce({
+			data: undefined,
+			error: { code: 10, message: "checksum mismatch" },
+		});
+		mockClient.GET.mockResolvedValue(divergedConfig());
+		renderEditor();
+		changeField("field-payments.fee_rate", "Fee Rate", "2.5");
+		fireEvent.click(screen.getByRole("button", { name: /Save batch/ }));
+
+		const dialog = await screen.findByTestId("conflict-resolver");
+		const row = within(dialog).getByTestId("conflict-payments.fee_rate");
+		fireEvent.click(within(row).getByTestId("conflict-compare-toggle-payments.fee_rate"));
+		const pane = within(row).getByTestId("conflict-compare-payments.fee_rate");
+		// theirs (committed v8 = 3) → mine (staged = 2.5): the exact rebase delta.
+		expect(within(within(pane).getByTestId("compare-side-theirs")).getByText("3")).toBeTruthy();
+		expect(within(within(pane).getByTestId("compare-side-mine")).getByText("2.5")).toBeTruthy();
 	});
 
 	it("rebasing re-applies 'keep mine' against the fresh checksum and re-POSTs", async () => {


### PR DESCRIPTION
## Summary
- Implements the transient states from the states reference across the screens, extending the components shipped in #88–#93 rather than duplicating them.
- Adds a per-field **compare** arm to the concurrency-conflict resolver (keep mine / take theirs / compare → rebase; sensitive stays `[REDACTED]` on both sides); distinguishes **explicit-null vs unset** in the read view via a new provenance helper; and adds a **broken-chain panel** built to the `AuditChainBreak` shape (`got` / `want` / `entry_id` / 0-based `position`).
- Verifies and adds tests for the existing validation-error states across every constraint kind, and confirms the rollback-rejected (`FAILED_PRECONDITION`) state stays distinct from a concurrency conflict (`ABORTED`).

## Test plan
- `npm run pre-commit` green (Biome, `tsc -b --noEmit`, vitest 393/393, vite build).
- New `ChainBreakPanel` + `provenance` tests; extended `ConflictResolver` / `ReadView` / `ConfigEditor` / `SystemOverview` tests; codecov patch ≥ 80% on changed files. E2E smoke unaffected.

## Notes
- The broken-chain panel renders to the documented `AuditChainBreak` shape, but its data prop is undefined today: the REST gateway exposes no `VerifyChain` and the audit model carries no hash fields, so it degrades to a clearly-marked pending-server note. Threading a real `breaks[]` activates it unchanged. Server follow-up: expose `VerifyChain` through the gateway (also raised in #91).

Closes #94
