### PR TITLE
feat: live Subscribe streaming for the read-view feed

### DIFF
--- a/src/__tests__/ReadView.live.test.tsx
+++ b/src/__tests__/ReadView.live.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import { ReadView } from "../pages/ReadView";
+
+type ConfigChange = components["schemas"]["v1ConfigChange"];
+
+// A minimal schema/config/audit baseline; the live stream overlays on top of it.
+const tenant = { name: "Acme Corp", schemaId: "s1", schemaVersion: 1 };
+const schema = {
+	name: "showcase",
+	fields: [
+		{ path: "payments.enabled", title: "Payments Enabled", type: "FIELD_TYPE_BOOL" },
+		{ path: "app.name", title: "Application Name", type: "FIELD_TYPE_STRING" },
+		{ path: "api.secret", title: "Secret", type: "FIELD_TYPE_JSON", sensitive: true },
+	],
+};
+const config = {
+	version: 8,
+	values: [
+		{ fieldPath: "payments.enabled", value: { boolValue: false }, checksum: "aaaaaaaa" },
+		{ fieldPath: "app.name", value: { stringValue: "Old Name" }, checksum: "bbbbbbbb" },
+		// Sensitive: server already redacted it to the literal [REDACTED].
+		{ fieldPath: "api.secret", value: { jsonValue: "[REDACTED]" } },
+	],
+};
+const audit = { entries: [] as components["schemas"]["v1AuditEntry"][] };
+
+vi.mock("../lib/hooks", () => ({
+	useTenant: () => ({ data: { tenant }, isLoading: false, error: null }),
+	useSchemaVersion: () => ({ data: { schema }, isLoading: false }),
+	useConfig: () => ({ data: { config }, isLoading: false }),
+	useAuditLog: () => ({ data: audit }),
+}));
+
+// The live stream is mocked per-test via this mutable value.
+let streamReturn: { changes: ConfigChange[]; status: "connecting" | "live" | "fallback" } = {
+	changes: [],
+	status: "fallback",
+};
+vi.mock("../lib/useConfigStream", async () => {
+	const actual =
+		await vi.importActual<typeof import("../lib/useConfigStream")>("../lib/useConfigStream");
+	return { ...actual, useConfigStream: () => streamReturn };
+});
+
+afterEach(() => {
+	streamReturn = { changes: [], status: "fallback" };
+});
+
+describe("ReadView — live streaming", () => {
+	it("shows the live indicator only while the stream is live", () => {
+		streamReturn = { changes: [], status: "fallback" };
+		const { rerender } = render(<ReadView tenantId="t1" />);
+		expect(screen.queryByTestId("live-indicator")).toBeNull();
+		expect(screen.getByText(/You're viewing, not editing\./)).toBeInTheDocument();
+
+		streamReturn = { changes: [], status: "live" };
+		rerender(<ReadView tenantId="t1" />);
+		expect(screen.getAllByTestId("live-indicator").length).toBeGreaterThan(0);
+		expect(screen.getByText(/Values stream live/)).toBeInTheDocument();
+	});
+
+	it("updates a value in place when a live change arrives", () => {
+		streamReturn = {
+			status: "live",
+			changes: [
+				{
+					tenantId: "t1",
+					version: 9,
+					fieldPath: "payments.enabled",
+					oldValue: { boolValue: false },
+					newValue: { boolValue: true },
+					changedBy: "carol@acme",
+					changedAt: new Date().toISOString(),
+				},
+			],
+		};
+		render(<ReadView tenantId="t1" />);
+
+		const row = screen.getByTestId("value-payments.enabled");
+		// The boolean pill now reads "true" (the live value), not the polled "false".
+		expect(within(row).getByText("true")).toBeInTheDocument();
+		// The row is flagged live (badge + data attribute).
+		expect(row).toHaveAttribute("data-live", "true");
+		expect(within(row).getAllByText("live").length).toBeGreaterThan(0);
+		// The change version is reflected in provenance.
+		expect(within(row).getByText(/set · v9/)).toBeInTheDocument();
+	});
+
+	it("prepends the live change to the recent-changes feed", () => {
+		streamReturn = {
+			status: "live",
+			changes: [
+				{
+					tenantId: "t1",
+					version: 9,
+					fieldPath: "app.name",
+					oldValue: { stringValue: "Old Name" },
+					newValue: { stringValue: "New Name" },
+					changedBy: "dave@acme",
+					changedAt: new Date().toISOString(),
+				},
+			],
+		};
+		render(<ReadView tenantId="t1" />);
+
+		// Feed footer announces the live source.
+		expect(screen.getByText(/streaming via/)).toBeInTheDocument();
+		// The actor + new value appear in the feed.
+		expect(screen.getAllByText(/dave@acme/).length).toBeGreaterThan(0);
+		expect(screen.getAllByText("New Name").length).toBeGreaterThan(0);
+		// The value row also reflects the streamed value.
+		const row = screen.getByTestId("value-app.name");
+		expect(within(row).getByText("New Name")).toBeInTheDocument();
+	});
+
+	it("keeps sensitive values redacted even when a live change targets them", () => {
+		streamReturn = {
+			status: "live",
+			changes: [
+				{
+					tenantId: "t1",
+					version: 9,
+					fieldPath: "api.secret",
+					oldValue: { jsonValue: "[REDACTED]" },
+					// A server would never stream cleartext for a write-only field, but the
+					// UI must never reveal regardless of what arrives.
+					newValue: { jsonValue: "super-secret-token" },
+					changedBy: "mallory@acme",
+					changedAt: new Date().toISOString(),
+				},
+			],
+		};
+		render(<ReadView tenantId="t1" />);
+
+		const row = screen.getByTestId("value-api.secret");
+		expect(within(row).getByText("[REDACTED]")).toBeInTheDocument();
+		// The streamed cleartext must not be rendered anywhere.
+		expect(screen.queryByText("super-secret-token")).toBeNull();
+	});
+
+	it("reflects a live clear as an explicit-null override", () => {
+		streamReturn = {
+			status: "live",
+			changes: [
+				{
+					tenantId: "t1",
+					version: 9,
+					fieldPath: "app.name",
+					oldValue: { stringValue: "Old Name" },
+					newValue: { stringValue: "" },
+					changedBy: "carol@acme",
+					changedAt: new Date().toISOString(),
+				},
+			],
+		};
+		render(<ReadView tenantId="t1" />);
+
+		const row = screen.getByTestId("value-app.name");
+		expect(within(row).getByText(/overrides the schema default/)).toBeInTheDocument();
+		expect(within(row).getByTestId("null-badge-app.name")).toHaveTextContent("null");
+	});
+});

--- a/src/lib/__tests__/useConfigStream.test.tsx
+++ b/src/lib/__tests__/useConfigStream.test.tsx
@@ -1,0 +1,332 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../../api/schema";
+import {
+	changeToAuditEntry,
+	isStreamClear,
+	streamTouchedPaths,
+	streamValueOverlay,
+	useConfigStream,
+} from "../useConfigStream";
+
+type ConfigChange = components["schemas"]["v1ConfigChange"];
+
+// Auth is read from context; stub it so the hook builds the same headers the
+// openapi-fetch client does, without needing an AuthProvider in the test.
+vi.mock("../auth", () => ({
+	useAuth: () => ({ auth: { subject: "carol@acme", role: "user", tenantId: "t1" } }),
+}));
+
+/** Build a ReadableStream that emits each chunk (as UTF-8 bytes) then closes. */
+function streamOf(chunks: string[]): ReadableStream<Uint8Array> {
+	const encoder = new TextEncoder();
+	let i = 0;
+	return new ReadableStream<Uint8Array>({
+		pull(controller) {
+			if (i < chunks.length) {
+				controller.enqueue(encoder.encode(chunks[i]));
+				i += 1;
+			} else {
+				controller.close();
+			}
+		},
+	});
+}
+
+/** A never-closing stream whose reader rejects when its signal aborts. */
+function pendingStream(signal: AbortSignal): ReadableStream<Uint8Array> {
+	return new ReadableStream<Uint8Array>({
+		pull() {
+			return new Promise<void>((_resolve, reject) => {
+				signal.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), {
+					once: true,
+				});
+			});
+		},
+	});
+}
+
+function frame(change: Partial<ConfigChange>): string {
+	return `${JSON.stringify({ result: { change } })}\n`;
+}
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = realFetch;
+	vi.restoreAllMocks();
+});
+
+describe("useConfigStream — pure helpers", () => {
+	it("isStreamClear is true only when an old value existed and the new is empty", () => {
+		expect(isStreamClear({ oldValue: { stringValue: "x" }, newValue: { stringValue: "" } })).toBe(
+			true,
+		);
+		expect(isStreamClear({ oldValue: { stringValue: "x" }, newValue: { stringValue: "y" } })).toBe(
+			false,
+		);
+		expect(isStreamClear({ newValue: { stringValue: "y" } })).toBe(false);
+		expect(isStreamClear({ oldValue: { stringValue: "x" } })).toBe(true);
+	});
+
+	it("streamValueOverlay keeps the newest value per path and maps a clear to null", () => {
+		const changes: ConfigChange[] = [
+			{ fieldPath: "a", newValue: { stringValue: "new-a" } }, // newest wins
+			{ fieldPath: "a", newValue: { stringValue: "old-a" } },
+			{ fieldPath: "b", oldValue: { stringValue: "had" }, newValue: { stringValue: "" } }, // clear
+			{ newValue: { stringValue: "no-path" } }, // ignored
+		];
+		const overlay = streamValueOverlay(changes);
+		expect(overlay.get("a")).toBe("new-a");
+		expect(overlay.get("b")).toBeNull();
+		expect(overlay.size).toBe(2);
+	});
+
+	it("streamTouchedPaths collects every changed field path", () => {
+		const touched = streamTouchedPaths([
+			{ fieldPath: "a" },
+			{ fieldPath: "b" },
+			{ fieldPath: "a" },
+			{},
+		]);
+		expect([...touched].sort()).toEqual(["a", "b"]);
+	});
+
+	it("changeToAuditEntry adapts a change to the audit-entry shape", () => {
+		const entry = changeToAuditEntry(
+			{
+				tenantId: "t1",
+				version: 9,
+				fieldPath: "payments.enabled",
+				oldValue: { boolValue: false },
+				newValue: { boolValue: true },
+				changedBy: "carol@acme",
+				changedAt: "2026-06-15T00:00:00Z",
+			},
+			0,
+		);
+		expect(entry).toMatchObject({
+			actor: "carol@acme",
+			action: "set_field",
+			fieldPath: "payments.enabled",
+			oldValue: "false",
+			newValue: "true",
+			configVersion: 9,
+		});
+		expect(entry.id).toContain("live-");
+	});
+
+	it("changeToAuditEntry marks a clear as clear_field", () => {
+		const entry = changeToAuditEntry(
+			{ fieldPath: "x", oldValue: { stringValue: "v" }, newValue: { stringValue: "" } },
+			1,
+		);
+		expect(entry.action).toBe("clear_field");
+	});
+});
+
+describe("useConfigStream — live path", () => {
+	it("parses framed NDJSON (incl. split lines) and accumulates changes newest-first", async () => {
+		globalThis.fetch = vi.fn(async () => {
+			return new Response(
+				streamOf([
+					frame({ fieldPath: "a", version: 2, newValue: { stringValue: "first" } }),
+					// Two frames in one chunk + a partial line that completes in the next chunk.
+					`${JSON.stringify({ result: { change: { fieldPath: "b", version: 3 } } })}\n{"result":{"chan`,
+					'ge":{"fieldPath":"c","version":4}}}\n',
+				]),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as typeof fetch;
+
+		const { result } = renderHook(() => useConfigStream("t1"));
+
+		await waitFor(() => expect(result.current.changes.length).toBe(3));
+		// Newest event is first (line-buffered parse stitched the split frame).
+		expect(result.current.changes[0].fieldPath).toBe("c");
+		expect(result.current.changes[2].fieldPath).toBe("a");
+	});
+
+	it("reports status 'live' while the stream is open", async () => {
+		const controller = new AbortController();
+		globalThis.fetch = vi.fn(async (_url: unknown, init?: RequestInit) => {
+			const signal = (init?.signal as AbortSignal) ?? controller.signal;
+			return new Response(pendingStream(signal), { status: 200 });
+		}) as unknown as typeof fetch;
+
+		const { result, unmount } = renderHook(() => useConfigStream("t1"));
+		await waitFor(() => expect(result.current.status).toBe("live"));
+		unmount();
+	});
+
+	it("sends the same auth headers and the subscribe URL", async () => {
+		const spy = vi.fn(async () => new Response(streamOf([]), { status: 200 }));
+		globalThis.fetch = spy as unknown as typeof fetch;
+
+		renderHook(() => useConfigStream("t1"));
+		await waitFor(() => expect(spy).toHaveBeenCalled());
+
+		const [url, init] = spy.mock.calls[0] as unknown as [string, RequestInit];
+		expect(url).toContain("/v1/tenants/t1/config:subscribe");
+		const headers = init.headers as Record<string, string>;
+		expect(headers["x-subject"]).toBe("carol@acme");
+		expect(headers["x-role"]).toBe("user");
+		expect(headers["x-tenant-id"]).toBe("t1");
+	});
+
+	it("skips garbled frames but keeps streaming", async () => {
+		globalThis.fetch = vi.fn(
+			async () =>
+				new Response(
+					streamOf(["not json\n", frame({ fieldPath: "ok", newValue: { stringValue: "v" } })]),
+					{ status: 200 },
+				),
+		) as typeof fetch;
+
+		const { result } = renderHook(() => useConfigStream("t1"));
+		await waitFor(() => expect(result.current.changes.length).toBe(1));
+		expect(result.current.changes[0].fieldPath).toBe("ok");
+	});
+
+	it("flushes a trailing line that was not newline-terminated", async () => {
+		globalThis.fetch = vi.fn(
+			async () =>
+				// Note: no trailing "\n" — the line is flushed when the stream closes.
+				new Response(streamOf([JSON.stringify({ result: { change: { fieldPath: "tail" } } })]), {
+					status: 200,
+				}),
+		) as typeof fetch;
+
+		const { result } = renderHook(() => useConfigStream("t1"));
+		await waitFor(() => expect(result.current.changes.length).toBe(1));
+		expect(result.current.changes[0].fieldPath).toBe("tail");
+	});
+
+	it("ignores empty lines and frames with no change payload", async () => {
+		globalThis.fetch = vi.fn(
+			async () =>
+				new Response(streamOf(["\n", `${JSON.stringify({ result: {} })}\n`, "   \n"]), {
+					status: 200,
+				}),
+		) as typeof fetch;
+
+		const { result } = renderHook(() => useConfigStream("t1"));
+		// No usable change → stays empty, then falls back when the stream closes.
+		await waitFor(() => expect(result.current.status).toBe("fallback"));
+		expect(result.current.changes).toEqual([]);
+	});
+});
+
+describe("useConfigStream — fallback path", () => {
+	it("falls back when fetch rejects", async () => {
+		globalThis.fetch = vi.fn(async () => {
+			throw new Error("network down");
+		}) as typeof fetch;
+
+		const { result } = renderHook(() => useConfigStream("t1"));
+		await waitFor(() => expect(result.current.status).toBe("fallback"));
+		expect(result.current.changes).toEqual([]);
+	});
+
+	it("falls back on a non-ok response", async () => {
+		globalThis.fetch = vi.fn(async () => new Response("nope", { status: 503 })) as typeof fetch;
+
+		const { result } = renderHook(() => useConfigStream("t1"));
+		await waitFor(() => expect(result.current.status).toBe("fallback"));
+	});
+
+	it("falls back when the response has no body", async () => {
+		globalThis.fetch = vi.fn(async () => ({
+			ok: true,
+			body: null,
+		})) as unknown as typeof fetch;
+
+		const { result } = renderHook(() => useConfigStream("t1"));
+		await waitFor(() => expect(result.current.status).toBe("fallback"));
+	});
+
+	it("falls back when a frame carries a mid-stream error", async () => {
+		globalThis.fetch = vi.fn(
+			async () =>
+				new Response(streamOf([`${JSON.stringify({ error: { message: "boom" } })}\n`]), {
+					status: 200,
+				}),
+		) as typeof fetch;
+
+		const { result } = renderHook(() => useConfigStream("t1"));
+		await waitFor(() => expect(result.current.status).toBe("fallback"));
+	});
+
+	it("falls back to refetch when the stream closes (server ended it)", async () => {
+		globalThis.fetch = vi.fn(
+			async () => new Response(streamOf([frame({ fieldPath: "a" })]), { status: 200 }),
+		) as typeof fetch;
+
+		const { result } = renderHook(() => useConfigStream("t1"));
+		await waitFor(() => expect(result.current.status).toBe("fallback"));
+		// The change seen before close is still retained.
+		expect(result.current.changes.length).toBe(1);
+	});
+
+	it("falls back immediately without a tenant id (no fetch)", async () => {
+		const spy = vi.fn();
+		globalThis.fetch = spy as unknown as typeof fetch;
+		const { result } = renderHook(() => useConfigStream(""));
+		await waitFor(() => expect(result.current.status).toBe("fallback"));
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it("falls back when the runtime lacks fetch", async () => {
+		// Simulate an environment without fetch (e.g. an older runtime).
+		(globalThis as { fetch?: typeof fetch }).fetch = undefined;
+		const { result } = renderHook(() => useConfigStream("t1"));
+		await waitFor(() => expect(result.current.status).toBe("fallback"));
+	});
+});
+
+describe("useConfigStream — teardown", () => {
+	let aborted: boolean;
+
+	beforeEach(() => {
+		aborted = false;
+	});
+
+	it("aborts the in-flight fetch and cancels the reader on unmount", async () => {
+		globalThis.fetch = vi.fn(async (_url: unknown, init?: RequestInit) => {
+			const signal = init?.signal as AbortSignal;
+			signal.addEventListener("abort", () => {
+				aborted = true;
+			});
+			return new Response(pendingStream(signal), { status: 200 });
+		}) as unknown as typeof fetch;
+
+		const { result, unmount } = renderHook(() => useConfigStream("t1"));
+		await waitFor(() => expect(result.current.status).toBe("live"));
+
+		unmount();
+		await waitFor(() => expect(aborted).toBe(true));
+	});
+
+	it("re-establishes the stream and clears changes when tenantId changes", async () => {
+		const calls: string[] = [];
+		globalThis.fetch = vi.fn(async (url: unknown, init?: RequestInit) => {
+			calls.push(String(url));
+			const signal = init?.signal as AbortSignal;
+			// First tenant: a pending stream we later abort; second: emits one change.
+			if (String(url).includes("/t1/")) {
+				return new Response(pendingStream(signal), { status: 200 });
+			}
+			return new Response(streamOf([frame({ fieldPath: "z" })]), { status: 200 });
+		}) as unknown as typeof fetch;
+
+		const { result, rerender } = renderHook(({ id }) => useConfigStream(id), {
+			initialProps: { id: "t1" },
+		});
+		await waitFor(() => expect(result.current.status).toBe("live"));
+
+		rerender({ id: "t2" });
+		await waitFor(() => expect(result.current.changes.some((c) => c.fieldPath === "z")).toBe(true));
+		expect(calls.some((u) => u.includes("/t1/"))).toBe(true);
+		expect(calls.some((u) => u.includes("/t2/"))).toBe(true);
+	});
+});

--- a/src/lib/useConfigStream.ts
+++ b/src/lib/useConfigStream.ts
@@ -1,0 +1,235 @@
+import { useEffect, useRef, useState } from "react";
+import type { components } from "../api/schema";
+import { useAuth } from "./auth";
+import { config } from "./config";
+import { typedValueToString } from "./fields";
+
+type ConfigChange = components["schemas"]["v1ConfigChange"];
+type AuditEntry = components["schemas"]["v1AuditEntry"];
+
+/** Whether a streamed change cleared the field (a deliberate write of null). */
+export function isStreamClear(change: ConfigChange): boolean {
+	const hadOld = change.oldValue !== undefined && typedValueToString(change.oldValue) !== "";
+	const hasNew = change.newValue !== undefined && typedValueToString(change.newValue) !== "";
+	return hadOld && !hasNew;
+}
+
+/**
+ * Fold live changes (newest-first) into a value overlay keyed by field path. The
+ * newest event for a path wins, so we keep only the first occurrence seen. A clear
+ * maps to `null` (signalling an explicit-null overlay, distinct from "absent").
+ */
+export function streamValueOverlay(changes: ConfigChange[]): Map<string, string | null> {
+	const overlay = new Map<string, string | null>();
+	for (const change of changes) {
+		const path = change.fieldPath;
+		if (!path || overlay.has(path)) continue;
+		overlay.set(path, isStreamClear(change) ? null : typedValueToString(change.newValue));
+	}
+	return overlay;
+}
+
+/**
+ * The set of field paths touched by live events — used to mark rows as freshly
+ * updated (a "live" badge + flash) and to drop their now-stale checksum, which the
+ * `ConfigChange` event does not carry.
+ */
+export function streamTouchedPaths(changes: ConfigChange[]): Set<string> {
+	const touched = new Set<string>();
+	for (const change of changes) {
+		if (change.fieldPath) touched.add(change.fieldPath);
+	}
+	return touched;
+}
+
+/**
+ * Adapt a streamed `v1ConfigChange` to the `v1AuditEntry` shape the recent-changes
+ * feed already renders, so live items and historical ones share one renderer. The
+ * change carries `TypedValue` old/new values (the feed reads strings) and a
+ * synthetic id keeps React keys stable across re-renders.
+ */
+export function changeToAuditEntry(change: ConfigChange, index: number): AuditEntry {
+	const cleared = isStreamClear(change);
+	return {
+		id: `live-${change.tenantId ?? ""}-${change.version ?? ""}-${change.fieldPath ?? ""}-${index}`,
+		tenantId: change.tenantId,
+		actor: change.changedBy,
+		action: cleared ? "clear_field" : "set_field",
+		fieldPath: change.fieldPath,
+		oldValue: change.oldValue !== undefined ? typedValueToString(change.oldValue) : undefined,
+		newValue: change.newValue !== undefined ? typedValueToString(change.newValue) : undefined,
+		configVersion: change.version,
+		createdAt: change.changedAt,
+	};
+}
+
+/**
+ * The streamed-message frame the REST gateway emits for a server-streaming RPC.
+ * grpc-gateway wraps each newline-delimited JSON object as `{"result": <msg>}`
+ * (and `{"error": <status>}` on a mid-stream error) — it is *not* SSE, so this is
+ * parsed by hand rather than via `EventSource`. The inner message is a
+ * `v1SubscribeResponse`, whose `change` is the actual `v1ConfigChange`.
+ */
+interface StreamFrame {
+	result?: { change?: ConfigChange };
+	error?: { message?: string };
+}
+
+/** Connection state of the live subscription. */
+export type StreamStatus = "connecting" | "live" | "fallback";
+
+export interface ConfigStream {
+	/** Live changes, newest first. Empty until the first event (or in fallback). */
+	changes: ConfigChange[];
+	/** "live" once the stream is open; "fallback" when it errored/unavailable. */
+	status: StreamStatus;
+}
+
+/**
+ * Build the absolute subscribe URL the same way `createApiClient` builds requests:
+ * on `config.apiUrl` (empty = same origin, proxied in dev/Docker). Field-path
+ * filtering is left empty so the read view receives every field's changes.
+ */
+function subscribeUrl(tenantId: string): string {
+	const base = config.apiUrl || "";
+	return `${base}/v1/tenants/${encodeURIComponent(tenantId)}/config:subscribe`;
+}
+
+/**
+ * Live config subscription for the read view, against the server `Subscribe` RPC
+ * via the REST gateway. Uses `fetch` + `ReadableStream` (not `EventSource`, which
+ * cannot set this app's `x-subject`/`x-role` metadata headers and expects SSE
+ * framing) so it can send the *same* auth headers as the openapi-fetch client and
+ * parse the gateway's NDJSON frames.
+ *
+ * Fail-safe by design: if `fetch` rejects, the response has no body, the
+ * environment lacks streaming, or a frame carries an error, the hook flips to
+ * `"fallback"` so the caller leans on its polling query data instead — the stream
+ * is the live path, the query hooks remain the source of truth underneath it.
+ *
+ * Teardown is total: on unmount or a `tenantId` change the in-flight fetch is
+ * aborted and the reader is cancelled, and a closed-over `cancelled` guard blocks
+ * any state update after teardown (no leaks, no act-after-unmount warnings).
+ */
+export function useConfigStream(tenantId: string): ConfigStream {
+	const { auth } = useAuth();
+	const [changes, setChanges] = useState<ConfigChange[]>([]);
+	const [status, setStatus] = useState<StreamStatus>("connecting");
+
+	// Auth is read through a ref so a change to the auth object doesn't tear down
+	// and re-open a healthy stream; the subscription only re-establishes per tenant.
+	const authRef = useRef(auth);
+	authRef.current = auth;
+
+	useEffect(() => {
+		if (!tenantId) {
+			setStatus("fallback");
+			return;
+		}
+
+		// No streaming in this environment (e.g. older runtime): fail safe to refetch.
+		if (typeof fetch !== "function" || typeof AbortController !== "function") {
+			setStatus("fallback");
+			return;
+		}
+
+		let cancelled = false;
+		const controller = new AbortController();
+		// Reset for the new tenant so stale events never bleed across a switch.
+		setChanges([]);
+		setStatus("connecting");
+
+		const fallback = () => {
+			if (!cancelled) setStatus("fallback");
+		};
+
+		const run = async () => {
+			let response: Response;
+			try {
+				const { subject, role, tenantId: authTenantId } = authRef.current;
+				const headers: Record<string, string> = {
+					accept: "application/json",
+					"x-subject": subject,
+					"x-role": role,
+				};
+				if (authTenantId) headers["x-tenant-id"] = authTenantId;
+
+				response = await fetch(subscribeUrl(tenantId), {
+					method: "GET",
+					headers,
+					signal: controller.signal,
+				});
+			} catch {
+				// Network failure / abort during connect → fall back to query data.
+				fallback();
+				return;
+			}
+
+			if (cancelled) return;
+			if (!response.ok || !response.body) {
+				fallback();
+				return;
+			}
+
+			setStatus("live");
+
+			const reader = response.body.getReader();
+			const decoder = new TextDecoder();
+			let buffer = "";
+
+			const handleLine = (line: string) => {
+				const trimmed = line.trim();
+				if (!trimmed) return;
+				let frame: StreamFrame;
+				try {
+					frame = JSON.parse(trimmed) as StreamFrame;
+				} catch {
+					// A partial/garbled frame is non-fatal — skip it, keep streaming.
+					return;
+				}
+				if (frame.error) {
+					// A mid-stream error frame ends the live path; lean on refetch.
+					fallback();
+					controller.abort();
+					return;
+				}
+				const change = frame.result?.change;
+				if (change && !cancelled) {
+					setChanges((prev) => [change, ...prev]);
+				}
+			};
+
+			try {
+				while (true) {
+					const { value, done } = await reader.read();
+					if (done) break;
+					if (cancelled) return;
+					buffer += decoder.decode(value, { stream: true });
+					// NDJSON: split on newlines, keep the trailing partial in the buffer.
+					let newlineIndex = buffer.indexOf("\n");
+					while (newlineIndex !== -1) {
+						handleLine(buffer.slice(0, newlineIndex));
+						buffer = buffer.slice(newlineIndex + 1);
+						newlineIndex = buffer.indexOf("\n");
+					}
+				}
+				// Flush any trailing line that wasn't newline-terminated.
+				if (buffer) handleLine(buffer);
+				// The server closed the stream — drop back to polling.
+				fallback();
+			} catch {
+				// Read error (incl. abort on teardown) → fall back to query data.
+				fallback();
+			}
+		};
+
+		run();
+
+		return () => {
+			cancelled = true;
+			controller.abort();
+		};
+	}, [tenantId]);
+
+	return { changes, status };
+}

--- a/src/pages/ReadView.tsx
+++ b/src/pages/ReadView.tsx
@@ -11,6 +11,12 @@ import { fieldTypeColor, fieldTypeIcon, fieldTypeLabel } from "../lib/field-type
 import { formatDuration, groupFields, typedValueToString } from "../lib/fields";
 import { useAuditLog, useConfig, useSchemaVersion, useTenant } from "../lib/hooks";
 import { type FieldProvenance, resolveFieldProvenance } from "../lib/provenance";
+import {
+	changeToAuditEntry,
+	streamTouchedPaths,
+	streamValueOverlay,
+	useConfigStream,
+} from "../lib/useConfigStream";
 
 type SchemaField = components["schemas"]["v1SchemaField"];
 type FieldType = components["schemas"]["v1FieldType"];
@@ -57,24 +63,61 @@ export function ReadView({ tenantId }: { tenantId: string }) {
 
 	const { data: auditData } = useAuditLog(tenantId);
 
+	// Live config subscription (server `Subscribe` RPC via the gateway). It is the
+	// live path; the query hooks above remain the fallback — when the stream can't
+	// open or errors, `status` is "fallback" and the read view runs on query data.
+	const { changes, status } = useConfigStream(tenantId);
+	const isLive = status === "live";
+
 	const fields = useMemo(() => schema?.fields ?? [], [schema]);
-	const entries = useMemo(() => auditData?.entries ?? [], [auditData]);
+
+	// Sensitive (write-only) field paths. The server redacts these on the value path,
+	// but the changes feed renders old→new deltas raw — so the feed must redact them
+	// too, lest a streamed (or audited) delta leak a value the value pane hides.
+	const sensitivePaths = useMemo(() => {
+		const s = new Set<string>();
+		for (const f of fields) if (f.sensitive && f.path) s.add(f.path);
+		return s;
+	}, [fields]);
+
+	// Streamed deltas overlaid on the polled data: live values win over query values,
+	// touched paths drop their now-stale checksum, and live changes are adapted to
+	// the audit-entry shape so the recent-changes feed renders them with one renderer.
+	const valueOverlay = useMemo(() => streamValueOverlay(changes), [changes]);
+	const touchedPaths = useMemo(() => streamTouchedPaths(changes), [changes]);
+	const liveEntries = useMemo(() => changes.map((c, i) => changeToAuditEntry(c, i)), [changes]);
+
+	// Live entries are newest-first already; prepend them to the polled audit log so
+	// provenance and the feed both see the most recent change first.
+	const entries = useMemo(
+		() => [...liveEntries, ...(auditData?.entries ?? [])],
+		[liveEntries, auditData],
+	);
 
 	const valueMap = useMemo(() => {
 		const m = new Map<string, string>();
 		for (const cv of config?.values ?? []) {
 			if (cv.fieldPath) m.set(cv.fieldPath, typedValueToString(cv.value));
 		}
+		// Overlay live values: a string overrides, an explicit-null clear removes the
+		// value (so the row reads as a stored null via the audit-derived provenance).
+		for (const [path, value] of valueOverlay) {
+			if (value === null) m.delete(path);
+			else m.set(path, value);
+		}
 		return m;
-	}, [config]);
+	}, [config, valueOverlay]);
 
 	const checksumMap = useMemo(() => {
 		const m = new Map<string, string>();
 		for (const cv of config?.values ?? []) {
 			if (cv.fieldPath && cv.checksum) m.set(cv.fieldPath, cv.checksum);
 		}
+		// The change event carries no checksum, so a live-updated field's old checksum
+		// is stale — drop it rather than show a value that no longer matches.
+		for (const path of touchedPaths) m.delete(path);
 		return m;
-	}, [config]);
+	}, [config, touchedPaths]);
 
 	// Per-field provenance: classifies each field as set / explicit-null / unset
 	// from its value presence + the audit log (the only source that distinguishes a
@@ -120,9 +163,15 @@ export function ReadView({ tenantId }: { tenantId: string }) {
 							</code>
 						</>
 					)}
-					{config && <> — config v{config.version}.</>} You're viewing, not editing.
+					{config && <> — config v{config.version}.</>}{" "}
+					{isLive
+						? "Values stream live; you're viewing, not editing."
+						: "You're viewing, not editing."}
 				</span>
-				<span className="ml-auto rounded-[var(--r-pill)] border border-line bg-surface px-2.5 py-0.5 text-xs font-medium text-fg-2">
+				{isLive && <LiveDot className="ml-auto" />}
+				<span
+					className={`rounded-[var(--r-pill)] border border-line bg-surface px-2.5 py-0.5 text-xs font-medium text-fg-2 ${isLive ? "" : "ml-auto"}`}
+				>
 					read-only
 				</span>
 			</div>
@@ -169,6 +218,7 @@ export function ReadView({ tenantId }: { tenantId: string }) {
 												value={valueMap.get(field.path ?? "")}
 												checksum={checksumMap.get(field.path ?? "")}
 												provenance={provenanceFor(field.path ?? "")}
+												live={touchedPaths.has(field.path ?? "")}
 											/>
 										))}
 									</div>
@@ -182,16 +232,29 @@ export function ReadView({ tenantId }: { tenantId: string }) {
 				<aside className="w-full shrink-0 lg:w-80">
 					<div className="mb-3 flex items-center gap-2">
 						<h2 className="text-sm font-semibold text-fg">Recent changes</h2>
+						{isLive && <LiveDot className="ml-auto" />}
 					</div>
 					<div className="space-y-1.5">
 						{entries.length === 0 && <p className="text-xs text-fg-3">No recorded changes yet.</p>}
-						{entries.map((e) => (
-							<FeedItem key={e.id} entry={e} />
+						{entries.map((e, i) => (
+							<FeedItem
+								key={e.id}
+								entry={e}
+								live={isLive && i < liveEntries.length}
+								sensitive={!!e.fieldPath && sensitivePaths.has(e.fieldPath)}
+							/>
 						))}
 					</div>
 					{entries.length > 0 && (
 						<p className="mt-3 font-mono text-[11px] text-fg-3">
-							{entries.length} recent entries · audited
+							{isLive ? (
+								<>
+									streaming via <span className="text-fg-2">Subscribe</span> · {entries.length}{" "}
+									entries · audited
+								</>
+							) : (
+								<>{entries.length} recent entries · audited</>
+							)}
 						</p>
 					)}
 				</aside>
@@ -200,25 +263,58 @@ export function ReadView({ tenantId }: { tenantId: string }) {
 	);
 }
 
+/**
+ * The "live" connection indicator — a pulsing `ok`-toned dot. Shown in the banner
+ * and the feed head only while the `Subscribe` stream is open; in fallback (refetch)
+ * mode it is absent, so the dot is an honest signal that values are streaming.
+ */
+function LiveDot({ className = "" }: { className?: string }) {
+	return (
+		<span
+			data-testid="live-indicator"
+			className={`inline-flex items-center gap-1.5 rounded-[var(--r-pill)] bg-ok-soft px-2 py-0.5 text-xs font-medium text-ok ${className}`}
+		>
+			<span className="relative flex h-1.5 w-1.5" aria-hidden="true">
+				<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-ok opacity-75 motion-reduce:hidden" />
+				<span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-ok" />
+			</span>
+			live
+		</span>
+	);
+}
+
+/** A small "live" pill marking a row/feed item touched by a live stream event. */
+function LiveBadge() {
+	return (
+		<span className="inline-flex items-center gap-1 rounded-[var(--r-pill)] bg-ok-soft px-1.5 py-0.5 font-mono text-[10px] font-medium text-ok">
+			<span className="h-1 w-1 rounded-full bg-ok" aria-hidden="true" />
+			live
+		</span>
+	);
+}
+
 function ValueRow({
 	field,
 	value,
 	checksum,
 	provenance,
+	live = false,
 }: {
 	field: SchemaField;
 	value: string | undefined;
 	checksum: string | undefined;
 	provenance: FieldProvenance;
+	live?: boolean;
 }) {
 	const isSet = provenance.state === "set";
 	const isExplicitNull = provenance.state === "explicit-null";
 	return (
 		<div
 			data-testid={`value-${field.path}`}
-			className={`grid grid-cols-[2.25rem_1fr_auto] gap-3 rounded-[var(--r-md)] border border-line bg-surface p-3 ${
-				field.deprecated ? "opacity-70" : ""
-			}`}
+			data-live={live ? "true" : undefined}
+			className={`grid grid-cols-[2.25rem_1fr_auto] gap-3 rounded-[var(--r-md)] border bg-surface p-3 transition-colors duration-700 ${
+				live ? "border-ok/50 bg-ok-soft" : "border-line"
+			} ${field.deprecated ? "opacity-70" : ""}`}
 		>
 			<span
 				title={fieldTypeLabel(field.type)}
@@ -240,6 +336,7 @@ function ValueRow({
 					{field.readOnly && <ReadOnlyBadge />}
 					{field.sensitive && <SensitiveBadge />}
 					{field.deprecated && <DeprecatedBadge />}
+					{live && <LiveBadge />}
 					{field.nullable && !isSet && (
 						<span className="rounded border border-dashed border-line px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-fg-3">
 							nullable
@@ -383,10 +480,23 @@ function ReadValue({
 	return <span className="text-sm text-fg">{value}</span>;
 }
 
-function FeedItem({ entry }: { entry: AuditEntry }) {
+function FeedItem({
+	entry,
+	live = false,
+	sensitive = false,
+}: {
+	entry: AuditEntry;
+	live?: boolean;
+	sensitive?: boolean;
+}) {
 	const isRollback = entry.action === "rollback";
 	return (
-		<div className="flex gap-2.5 rounded-[var(--r-md)] border border-line bg-surface p-2.5">
+		<div
+			data-live={live ? "true" : undefined}
+			className={`flex gap-2.5 rounded-[var(--r-md)] border bg-surface p-2.5 ${
+				live ? "border-ok/50 bg-ok-soft" : "border-line"
+			}`}
+		>
 			<span
 				className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-accent-soft font-mono text-[11px] font-semibold text-accent"
 				aria-hidden="true"
@@ -397,6 +507,7 @@ function FeedItem({ entry }: { entry: AuditEntry }) {
 				<div className="flex items-center gap-1.5">
 					<b className="font-semibold text-fg">{entry.actor}</b>
 					<span className="text-fg-3">{entry.action}</span>
+					{live && <LiveBadge />}
 					<span className="ml-auto text-fg-3">{timeAgo(entry.createdAt ?? "")}</span>
 				</div>
 				<div className="mt-0.5 text-fg-2">
@@ -407,12 +518,21 @@ function FeedItem({ entry }: { entry: AuditEntry }) {
 					) : entry.fieldPath ? (
 						<>
 							set <code className="font-mono">{entry.fieldPath}</code>
-							{entry.oldValue !== undefined && entry.newValue !== undefined && (
+							{sensitive ? (
+								// Write-only field: never surface the old/new delta, even live.
 								<>
 									{" "}
-									<span className="text-fg-3 line-through">{entry.oldValue}</span> →{" "}
-									<span className="text-fg">{entry.newValue}</span>
+									<RedactedValue />
 								</>
+							) : (
+								entry.oldValue !== undefined &&
+								entry.newValue !== undefined && (
+									<>
+										{" "}
+										<span className="text-fg-3 line-through">{entry.oldValue}</span> →{" "}
+										<span className="text-fg">{entry.newValue}</span>
+									</>
+								)
 							)}
 						</>
 					) : (


### PR DESCRIPTION
## Summary
- Replaces the read-view's query-refetch feed with a real stream against the server `Subscribe` RPC via the REST gateway: a new `useConfigStream` hook overlays live deltas onto the polled config — values update in place, live changes prepend to the recent-changes feed, and a pulsing "live" indicator marks the connection.
- Uses `fetch` + `ReadableStream` (not `EventSource`, which cannot set the `x-subject`/`x-role` metadata headers and expects SSE), parsing the gateway's newline-delimited JSON frames; the auth headers + base URL are reused from the existing API client.
- Graceful fallback: any stream error or unavailability falls back to the existing `useConfig`/`useAuditLog` polling (never removed), so the read-view always updates. The stream is fully torn down on unmount / tenant change (`AbortController` + a cancel guard).
- Sensitive fields stay `[REDACTED]` in streamed updates too, including the feed's old→new delta.

## Test plan
- `npm run pre-commit` green (Biome, `tsc -b --noEmit`, vitest 418/418, vite build).
- New `useConfigStream` + `ReadView.live` tests (mock `fetch` → a `ReadableStream` of framed JSON; fallback path; teardown/abort); codecov patch ≥ 80% on changed files. E2E smoke unaffected.

Closes #95
