### PR TITLE
Surface config re-fetch errors in conflict recovery

### DIFF
--- a/src/pages/tenants/ConfigEditor.tsx
+++ b/src/pages/tenants/ConfigEditor.tsx
@@ -217,9 +217,15 @@ export function ConfigEditor({ tenantId }: { tenantId: string }) {
 
 	/** Re-fetch the latest config and compute the conflicting fields for the resolver. */
 	const openConflictResolver = useCallback(async () => {
-		const { data } = await client.GET("/v1/tenants/{tenantId}/config", {
+		const { data, error: err } = await client.GET("/v1/tenants/{tenantId}/config", {
 			params: { path: { tenantId } },
 		});
+		// A failed re-fetch would open the resolver with empty values/checksums; surface
+		// the error and abort instead so the user keeps their staged edits intact.
+		if (err) {
+			toast.error(formatError(err));
+			return;
+		}
 		const fresh = data?.config;
 		const freshValues = new Map<string, string>();
 		const freshChecks = new Map<string, string>();
@@ -254,7 +260,7 @@ export function ConfigEditor({ tenantId }: { tenantId: string }) {
 		}
 		setConflictVersions({ stale: config?.version, fresh: fresh?.version });
 		setConflicts(list);
-	}, [client, tenantId, pending, fieldByPath, serverValueMap, config]);
+	}, [client, tenantId, pending, fieldByPath, serverValueMap, config, toast]);
 
 	const saveMutation = useMutation({
 		mutationFn: async () => {
@@ -279,9 +285,12 @@ export function ConfigEditor({ tenantId }: { tenantId: string }) {
 	// them, and re-submit. "take theirs" fields are dropped (the server value wins).
 	const rebaseMutation = useMutation({
 		mutationFn: async (resolutions: Map<string, Resolution>) => {
-			const { data } = await client.GET("/v1/tenants/{tenantId}/config", {
+			const { data, error: err } = await client.GET("/v1/tenants/{tenantId}/config", {
 				params: { path: { tenantId } },
 			});
+			// Without the fresh checksums a re-submit would carry missing ones; throw so
+			// onError surfaces it rather than POSTing against an empty freshChecks map.
+			if (err) throw err;
 			const freshChecks = new Map<string, string>();
 			for (const cv of data?.config?.values ?? []) {
 				if (cv.fieldPath && cv.checksum) freshChecks.set(cv.fieldPath, cv.checksum);

--- a/src/pages/tenants/__tests__/ConfigEditor.test.tsx
+++ b/src/pages/tenants/__tests__/ConfigEditor.test.tsx
@@ -845,3 +845,52 @@ describe("ConfigEditor — rebase failure paths", () => {
 		expect(mockClient.POST).toHaveBeenCalledTimes(1);
 	});
 });
+
+describe("ConfigEditor — conflict re-fetch failure", () => {
+	it("surfaces a toast and does not open the resolver when the re-fetch GET fails", async () => {
+		// Save is rejected ABORTED, but the config re-fetch then fails. The resolver
+		// must NOT open with empty values/checksums — the error is surfaced instead.
+		mockClient.POST.mockResolvedValueOnce({
+			data: undefined,
+			error: { code: 10, message: "checksum mismatch" },
+		});
+		mockClient.GET.mockResolvedValue({
+			data: undefined,
+			error: { message: "re-fetch boom" },
+		});
+
+		renderEditor();
+		changeField("field-payments.fee_rate", "Fee Rate", "2.5");
+		fireEvent.click(screen.getByRole("button", { name: /Save batch/ }));
+
+		expect(await screen.findByText("re-fetch boom")).toBeInTheDocument();
+		expect(screen.queryByTestId("conflict-resolver")).toBeNull();
+		// The staged edit survives — only the initial save POST fired.
+		expect(mockClient.POST).toHaveBeenCalledTimes(1);
+	});
+
+	it("surfaces the rebase via onError when the rebase re-fetch GET fails", async () => {
+		// Initial save: ABORTED → the first GET succeeds and opens the resolver.
+		mockClient.POST.mockResolvedValueOnce({
+			data: undefined,
+			error: { code: 10, message: "checksum mismatch" },
+		});
+		mockClient.GET.mockResolvedValueOnce(divergedConfig());
+		// Rebase re-fetch: fails, so nothing is re-submitted with missing checksums.
+		mockClient.GET.mockResolvedValueOnce({
+			data: undefined,
+			error: { message: "rebase fetch boom" },
+		});
+
+		renderEditor();
+		changeField("field-payments.fee_rate", "Fee Rate", "2.5");
+		fireEvent.click(screen.getByRole("button", { name: /Save batch/ }));
+
+		const dialog = await screen.findByTestId("conflict-resolver");
+		fireEvent.click(within(dialog).getByRole("button", { name: /Rebase & save/ }));
+
+		expect(await screen.findByText("rebase fetch boom")).toBeInTheDocument();
+		// No batchSet against empty checksums — only the initial save POST ever fired.
+		expect(mockClient.POST).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary
- The conflict-recovery path re-fetched the latest config but discarded the GET error. A failed re-fetch opened the resolver with empty `theirs` values and checksums, or re-submitted the rebase against an empty checksum map.
- `openConflictResolver` now checks the error, shows a toast, and aborts instead of opening an empty resolver.
- `rebaseMutation` now throws on the re-fetch error so its existing `onError` surfaces it, rather than POSTing with missing checksums.

## Test plan
- [x] New unit tests for both flows: when the config re-fetch returns an error, the resolver stays closed with an error toast, and the rebase surfaces the error via `onError` with no `batchSet` POST.
- [x] `npm run pre-commit` green — biome, tsc, 420 vitest tests, production build.

Closes #103