### PR TITLE
Cap the live config-changes buffer

### DIFF
--- a/src/lib/__tests__/useConfigStream.test.tsx
+++ b/src/lib/__tests__/useConfigStream.test.tsx
@@ -4,6 +4,7 @@ import type { components } from "../../api/schema";
 import {
 	changeToAuditEntry,
 	isStreamClear,
+	MAX_LIVE_CHANGES,
 	streamTouchedPaths,
 	streamValueOverlay,
 	useConfigStream,
@@ -145,6 +146,28 @@ describe("useConfigStream — live path", () => {
 		// Newest event is first (line-buffered parse stitched the split frame).
 		expect(result.current.changes[0].fieldPath).toBe("c");
 		expect(result.current.changes[2].fieldPath).toBe("a");
+	});
+
+	it("caps retained changes at MAX_LIVE_CHANGES, keeping the newest", async () => {
+		// Stream more frames than the cap; each carries a monotonically rising version.
+		const total = MAX_LIVE_CHANGES + 50;
+		const frames = Array.from({ length: total }, (_unused, i) =>
+			frame({ fieldPath: `f${i}`, version: i }),
+		);
+		globalThis.fetch = vi.fn(
+			async () => new Response(streamOf(frames), { status: 200 }),
+		) as typeof fetch;
+
+		const { result } = renderHook(() => useConfigStream("t1"));
+
+		await waitFor(() => expect(result.current.changes.length).toBe(MAX_LIVE_CHANGES));
+		// The buffer never exceeds the cap, and the newest event sits at index 0.
+		expect(result.current.changes.length).toBe(MAX_LIVE_CHANGES);
+		expect(result.current.changes[0].fieldPath).toBe(`f${total - 1}`);
+		// The oldest retained entry is the start of the newest window, not f0.
+		expect(result.current.changes[MAX_LIVE_CHANGES - 1].fieldPath).toBe(
+			`f${total - MAX_LIVE_CHANGES}`,
+		);
 	});
 
 	it("reports status 'live' while the stream is open", async () => {

--- a/src/lib/useConfigStream.ts
+++ b/src/lib/useConfigStream.ts
@@ -7,6 +7,10 @@ import { typedValueToString } from "./fields";
 type ConfigChange = components["schemas"]["v1ConfigChange"];
 type AuditEntry = components["schemas"]["v1AuditEntry"];
 
+/** Cap on retained live changes: the read-view feed only shows recent activity, so
+ * keeping an unbounded history just grows memory and re-render cost for no benefit. */
+export const MAX_LIVE_CHANGES = 200;
+
 /** Whether a streamed change cleared the field (a deliberate write of null). */
 export function isStreamClear(change: ConfigChange): boolean {
 	const hadOld = change.oldValue !== undefined && typedValueToString(change.oldValue) !== "";
@@ -195,7 +199,7 @@ export function useConfigStream(tenantId: string): ConfigStream {
 				}
 				const change = frame.result?.change;
 				if (change && !cancelled) {
-					setChanges((prev) => [change, ...prev]);
+					setChanges((prev) => [change, ...prev].slice(0, MAX_LIVE_CHANGES));
 				}
 			};
 


### PR DESCRIPTION
## Summary
- The live Subscribe feed prepended every streamed change with no cap, so a long-lived read view accumulated the whole session's deltas — growing memory and the cost of the `useMemo`s that consume the buffer (`streamValueOverlay`, `streamTouchedPaths`, `liveEntries`).
- Retain only the newest `MAX_LIVE_CHANGES` (200) entries via `.slice(0, MAX_LIVE_CHANGES)`.

## Test plan
- [x] New test streams `MAX_LIVE_CHANGES + 50` frames and asserts the buffer caps at 200, with the newest change at index 0 and the oldest dropped.
- [x] `npm run pre-commit` green — biome, tsc, 421 vitest tests, production build.

Closes #104