### PR TITLE
Derive live-feed entry ids from change fields

### DIFF
--- a/src/lib/__tests__/useConfigStream.test.tsx
+++ b/src/lib/__tests__/useConfigStream.test.tsx
@@ -94,18 +94,15 @@ describe("useConfigStream — pure helpers", () => {
 	});
 
 	it("changeToAuditEntry adapts a change to the audit-entry shape", () => {
-		const entry = changeToAuditEntry(
-			{
-				tenantId: "t1",
-				version: 9,
-				fieldPath: "payments.enabled",
-				oldValue: { boolValue: false },
-				newValue: { boolValue: true },
-				changedBy: "carol@acme",
-				changedAt: "2026-06-15T00:00:00Z",
-			},
-			0,
-		);
+		const entry = changeToAuditEntry({
+			tenantId: "t1",
+			version: 9,
+			fieldPath: "payments.enabled",
+			oldValue: { boolValue: false },
+			newValue: { boolValue: true },
+			changedBy: "carol@acme",
+			changedAt: "2026-06-15T00:00:00Z",
+		});
 		expect(entry).toMatchObject({
 			actor: "carol@acme",
 			action: "set_field",
@@ -118,11 +115,39 @@ describe("useConfigStream — pure helpers", () => {
 	});
 
 	it("changeToAuditEntry marks a clear as clear_field", () => {
-		const entry = changeToAuditEntry(
-			{ fieldPath: "x", oldValue: { stringValue: "v" }, newValue: { stringValue: "" } },
-			1,
-		);
+		const entry = changeToAuditEntry({
+			fieldPath: "x",
+			oldValue: { stringValue: "v" },
+			newValue: { stringValue: "" },
+		});
 		expect(entry.action).toBe("clear_field");
+	});
+
+	it("changeToAuditEntry derives a stable id from change fields, independent of position", () => {
+		const change: ConfigChange = {
+			tenantId: "t1",
+			version: 9,
+			fieldPath: "payments.enabled",
+			newValue: { boolValue: true },
+			changedAt: "2026-06-15T00:00:00Z",
+		};
+		// The buffer is prepend-only: a newer change shifts the original's index.
+		const newer: ConfigChange = {
+			tenantId: "t1",
+			version: 10,
+			fieldPath: "payments.fee",
+			newValue: { stringValue: "1" },
+			changedAt: "2026-06-15T00:01:00Z",
+		};
+
+		// id when the change is the only (index 0) entry…
+		const before = changeToAuditEntry(change);
+		// …and after a delta is prepended, pushing it to index 1.
+		const after = [newer, change].map((c) => changeToAuditEntry(c));
+
+		expect(after[1].id).toBe(before.id);
+		// Distinct changes still get distinct ids, so React keys stay unique.
+		expect(after[0].id).not.toBe(after[1].id);
 	});
 });
 

--- a/src/lib/useConfigStream.ts
+++ b/src/lib/useConfigStream.ts
@@ -50,12 +50,14 @@ export function streamTouchedPaths(changes: ConfigChange[]): Set<string> {
  * Adapt a streamed `v1ConfigChange` to the `v1AuditEntry` shape the recent-changes
  * feed already renders, so live items and historical ones share one renderer. The
  * change carries `TypedValue` old/new values (the feed reads strings) and a
- * synthetic id keeps React keys stable across re-renders.
+ * synthetic id derived from change-intrinsic fields (tenant, version, field path,
+ * changedAt) keeps React keys stable across re-renders — the buffer is prepend-only,
+ * so the id must not depend on the change's position in the array.
  */
-export function changeToAuditEntry(change: ConfigChange, index: number): AuditEntry {
+export function changeToAuditEntry(change: ConfigChange): AuditEntry {
 	const cleared = isStreamClear(change);
 	return {
-		id: `live-${change.tenantId ?? ""}-${change.version ?? ""}-${change.fieldPath ?? ""}-${index}`,
+		id: `live-${change.tenantId ?? ""}-${change.version ?? ""}-${change.fieldPath ?? ""}-${change.changedAt ?? ""}`,
 		tenantId: change.tenantId,
 		actor: change.changedBy,
 		action: cleared ? "clear_field" : "set_field",

--- a/src/pages/ReadView.tsx
+++ b/src/pages/ReadView.tsx
@@ -85,7 +85,7 @@ export function ReadView({ tenantId }: { tenantId: string }) {
 	// the audit-entry shape so the recent-changes feed renders them with one renderer.
 	const valueOverlay = useMemo(() => streamValueOverlay(changes), [changes]);
 	const touchedPaths = useMemo(() => streamTouchedPaths(changes), [changes]);
-	const liveEntries = useMemo(() => changes.map((c, i) => changeToAuditEntry(c, i)), [changes]);
+	const liveEntries = useMemo(() => changes.map((c) => changeToAuditEntry(c)), [changes]);
 
 	// Live entries are newest-first already; prepend them to the polled audit log so
 	// provenance and the feed both see the most recent change first.


### PR DESCRIPTION
## Summary
- `changeToAuditEntry` baked the array index into the synthetic id and ReadView passed the map index. The buffer is prepend-only, so every new delta shifted all indices and changed the id of existing feed rows on each tick — remounting them, the opposite of the comment's promise.
- The id is now derived from change-intrinsic fields (tenant, version, field path, `changedAt`), so an entry's key is stable across re-renders.

## Test plan
- [x] New test asserts an entry's id is identical before and after a new change is prepended (position-independent), and distinct entries keep distinct ids.
- [x] All `changeToAuditEntry` callers updated to the no-index signature.
- [x] `npm run pre-commit` green — biome, tsc, 422 vitest tests, production build.

Closes #105