### PR TITLE
Trim value before enum and bool validation

### DIFF
--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -37,6 +37,11 @@ describe("validateField — enum (any type)", () => {
 		const f = field("FIELD_TYPE_STRING", { enumValues: ["USD", "EUR"] });
 		expect(validateField(f, "JPY")).toMatch(/Must be one of: USD, EUR\./);
 	});
+
+	it("accepts a whitespace-padded enum value (compared against the trimmed value)", () => {
+		const f = field("FIELD_TYPE_STRING", { enumValues: ["USD", "EUR"] });
+		expect(validateField(f, " USD ")).toBeNull();
+	});
 });
 
 describe("validateField — int", () => {
@@ -96,6 +101,10 @@ describe("validateField — bool", () => {
 		expect(validateField(field("FIELD_TYPE_BOOL"), "true")).toBeNull();
 		expect(validateField(field("FIELD_TYPE_BOOL"), "false")).toBeNull();
 		expect(validateField(field("FIELD_TYPE_BOOL"), "yes")).toMatch(/Must be "true" or "false"/);
+	});
+
+	it("accepts a whitespace-padded bool value (compared against the trimmed value)", () => {
+		expect(validateField(field("FIELD_TYPE_BOOL"), " true ")).toBeNull();
 	});
 });
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -27,7 +27,7 @@ export function validateField(field: SchemaField, value: string): string | null 
 	}
 
 	// Enum applies to any type.
-	if (c.enumValues && c.enumValues.length > 0 && !c.enumValues.includes(value)) {
+	if (c.enumValues && c.enumValues.length > 0 && !c.enumValues.includes(trimmed)) {
 		return `Must be one of: ${c.enumValues.join(", ")}.`;
 	}
 
@@ -37,7 +37,7 @@ export function validateField(field: SchemaField, value: string): string | null 
 		case "FIELD_TYPE_NUMBER":
 			return validateNumber(trimmed, c);
 		case "FIELD_TYPE_BOOL":
-			return value === "true" || value === "false" ? null : 'Must be "true" or "false".';
+			return trimmed === "true" || trimmed === "false" ? null : 'Must be "true" or "false".';
 		case "FIELD_TYPE_STRING":
 			return validateString(value, c);
 		case "FIELD_TYPE_DURATION":


### PR DESCRIPTION
## Summary
- `validateField`'s enum and bool checks compared the raw value while every numeric branch validated the trimmed value, so a whitespace-padded enum or bool value (e.g. `" USD "`, `" true "`) was wrongly rejected even though the same padding was accepted for numeric types.
- Both checks now compare the trimmed value. String and json validation keep using the raw value, where whitespace is significant.

## Test plan
- [x] New tests: padded enum (`" USD "`) and padded bool (`" true "`) validate as OK; existing invalid enum/bool cases still return their errors.
- [x] `npm run pre-commit` green — biome, tsc, 424 vitest tests, production build.

Closes #106