### PR TITLE
Use semantic color tokens in body and FieldBadges

### DIFF
--- a/src/components/FieldBadges.tsx
+++ b/src/components/FieldBadges.tsx
@@ -2,7 +2,7 @@
 
 export function DeprecatedBadge() {
 	return (
-		<span className="rounded bg-red-100 px-1.5 py-0.5 text-xs font-medium text-red-700 dark:bg-red-900 dark:text-red-300">
+		<span className="rounded bg-danger-soft px-1.5 py-0.5 text-xs font-medium text-danger">
 			Deprecated
 		</span>
 	);
@@ -10,7 +10,7 @@ export function DeprecatedBadge() {
 
 export function ReadOnlyBadge() {
 	return (
-		<span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+		<span className="rounded bg-surface-3 px-1.5 py-0.5 text-xs font-medium text-fg-2">
 			Read-only
 		</span>
 	);
@@ -18,7 +18,7 @@ export function ReadOnlyBadge() {
 
 export function WriteOnceBadge({ hasValue }: { hasValue?: boolean }) {
 	return (
-		<span className="rounded bg-purple-100 px-1.5 py-0.5 text-xs font-medium text-purple-700 dark:bg-purple-900 dark:text-purple-300">
+		<span className="rounded bg-lock-soft px-1.5 py-0.5 text-xs font-medium text-lock">
 			{hasValue ? "Immutable" : "Write-once"}
 		</span>
 	);
@@ -26,7 +26,7 @@ export function WriteOnceBadge({ hasValue }: { hasValue?: boolean }) {
 
 export function SensitiveBadge() {
 	return (
-		<span className="rounded bg-amber-100 px-1.5 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900 dark:text-amber-300">
+		<span className="rounded bg-warn-soft px-1.5 py-0.5 text-xs font-medium text-warn">
 			Sensitive
 		</span>
 	);

--- a/src/index.css
+++ b/src/index.css
@@ -109,6 +109,6 @@
 }
 
 body {
-	@apply bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100;
+	@apply bg-canvas text-fg;
 	font-family: var(--sans);
 }


### PR DESCRIPTION
## Summary
- The `body` rule and the field badges hardcoded the raw Tailwind palette instead of the redesign's semantic tokens, so a future token change would skip them.
- `body` now uses `bg-canvas`/`text-fg`; the badges use the `danger`, `lock`, `warn`, and `surface`/`fg` tokens. The `dark:` variants are dropped because the tokens already flip via the `.dark` class. `RedactedValue` already used the `warn` token.

## Test plan
- [x] `npm run pre-commit` green — biome, tsc, 424 vitest tests, and the Vite/Tailwind build (which validates every token class resolves).
- [x] No test asserts badge class names, so none needed updating; badge tests assert rendered text only.

Closes #107