### PR TITLE
Close App full-mode test gaps

### DIFF
--- a/src/__tests__/App.full.test.tsx
+++ b/src/__tests__/App.full.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from "react-router-dom";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../App";
 import { STORAGE_KEY_AUTH } from "../lib/constants";
+import { resolveEntryPath } from "../lib/nav";
 
 vi.mock("../lib/config", () => ({
 	config: {
@@ -23,6 +24,7 @@ vi.mock("../pages/NotFound", () => ({ NotFound: () => <div data-testid="not-foun
 vi.mock("../pages/tenants/TenantConfig", () => ({
 	TenantConfig: () => <div data-testid="tenant-config" />,
 }));
+vi.mock("../pages/schemas/SchemaAuthor", () => ({ SchemaAuthor: () => null }));
 vi.mock("../pages/schemas/SchemaDetail", () => ({ SchemaDetail: () => null }));
 vi.mock("../pages/schemas/SchemaImport", () => ({ SchemaImport: () => null }));
 vi.mock("../pages/schemas/SchemaList", () => ({ SchemaList: () => <div data-testid="schemas" /> }));
@@ -33,6 +35,15 @@ vi.mock("../pages/tenants/TenantList", () => ({
 	TenantList: () => <div data-testid="tenant-list" />,
 }));
 vi.mock("../pages/tenants/TenantUsage", () => ({ TenantUsage: () => null }));
+
+// Partial-mock nav so resolveEntryPath becomes a spy that defaults to the real
+// implementation — existing routing tests are unaffected, but a single test can
+// override it to exercise RoleEntry's otherwise-unreachable negative branch.
+// buildRail and everything else stay real (AppShell depends on buildRail).
+vi.mock("../lib/nav", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/nav")>();
+	return { ...actual, resolveEntryPath: vi.fn(actual.resolveEntryPath) };
+});
 
 beforeAll(() => {
 	Object.defineProperty(window, "matchMedia", {
@@ -71,6 +82,17 @@ describe("App in full mode", () => {
 		localStorage.setItem(STORAGE_KEY_AUTH, JSON.stringify({ subject: "carol", role: "admin" }));
 		renderApp("/");
 		expect(screen.getByTestId("tenant-list")).toBeInTheDocument();
+	});
+
+	it("renders Home, not the overview, for a non-superadmin who resolves to the index route", () => {
+		// RoleEntry's negative branch is unreachable through real role logic (only
+		// superadmin resolves to "/", and only superadmin passes
+		// canViewSystemOverview), so force the resolver to "/" for a "user" role.
+		vi.mocked(resolveEntryPath).mockReturnValueOnce("/");
+		localStorage.setItem(STORAGE_KEY_AUTH, JSON.stringify({ subject: "dave", role: "user" }));
+		renderApp("/");
+		expect(screen.getByTestId("home")).toBeInTheDocument();
+		expect(screen.queryByTestId("system-overview")).not.toBeInTheDocument();
 	});
 
 	it("renders the config dispatcher for /tenants/:id", () => {


### PR DESCRIPTION
## Summary
- `App.full.test.tsx` mocked 12 of the 13 page components `App` imports, leaving `SchemaAuthor` unmocked — a future test visiting `/schemas/:id/author` would mount the real component and its API hooks.
- `RoleEntry`'s negative branch (a non-superadmin who resolves to the index route renders `Home`, not `SystemOverview`) was uncovered.

## Test plan
- [x] Mock `SchemaAuthor` (now all 13 page components are mocked).
- [x] New test forces `resolveEntryPath` to `/` for a non-superadmin and asserts `Home` renders, not `SystemOverview`. The `resolveEntryPath` spy defaults to the real implementation, so the existing routing tests are unaffected.
- [x] `npm run pre-commit` green — biome, tsc, 425 vitest tests, production build.

Closes #108