### PR TITLE
Override js-yaml to 4.2.0 to clear DoS advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2773,10 +2773,20 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
 		"typescript": "~5.9.3",
 		"vite": "^8.0.16",
 		"vitest": "^4.1.4"
+	},
+	"overrides": {
+		"js-yaml": "^4.2.0"
 	}
 }


### PR DESCRIPTION
## Summary
- `@redocly/openapi-core` (a transitive dev dependency via `openapi-typescript`) pins `js-yaml` at 4.1.1, which carries [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) — a quadratic-complexity denial of service in YAML merge-key alias handling. Fixed in 4.2.0.
- The patched `@redocly` (2.x, `js-yaml ^4.2.0`) is a major bump that `openapi-typescript@7.13.0` (the latest) does not accept, so a plain update cannot move it. Add an npm `overrides` entry forcing `js-yaml` to `^4.2.0`.
- This dependency is dev/build-time only — `js-yaml` is reached solely by `openapi-typescript` parsing our own `openapi.json` — so real exposure was minimal; this clears the Dependabot alert.

## Test plan
- [x] `npm explain js-yaml` confirms `4.2.0` (overridden); `npm audit` reports 0 vulnerabilities.
- [x] `npm run generate` runs clean with 4.2.0 (the `openapi-typescript` consumer still works).
- [x] `npm run pre-commit` green — biome, tsc, vitest, production build.

Refs GHSA-h67p-54hq-rp68