### PR TITLE
chore: release decree-ui v0.2.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "decree-ui",
-	"version": "0.1.0-alpha.1",
+	"version": "0.2.0-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "decree-ui",
-			"version": "0.1.0-alpha.1",
+			"version": "0.2.0-alpha.1",
 			"dependencies": {
 				"@fontsource/ibm-plex-mono": "^5.2.7",
 				"@fontsource/ibm-plex-sans": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "decree-ui",
 	"private": true,
-	"version": "0.1.0-alpha.1",
+	"version": "0.2.0-alpha.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",


### PR DESCRIPTION
## Summary
- Bump decree-ui to `0.2.0-alpha.1`, marking the hi-fi redesign as a distinct release line.

## Test plan
- [x] `npm run lint` (biome) + `npm run typecheck` — clean
- [x] `npm test` — 425 passed
- [x] `npm run build` — clean (bakes `__APP_VERSION__` = 0.2.0-alpha.1)
- [ ] PR CI incl. E2E
- [ ] Tag `v0.2.0-alpha.1` → publish.yml → `ghcr.io/opendecree/decree-ui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)