### PR TITLE
chore: release decree-ui v0.2.0-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "decree-ui",
-	"version": "0.2.0-alpha.1",
+	"version": "0.2.0-alpha.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "decree-ui",
-			"version": "0.2.0-alpha.1",
+			"version": "0.2.0-alpha.2",
 			"dependencies": {
 				"@fontsource/ibm-plex-mono": "^5.2.7",
 				"@fontsource/ibm-plex-sans": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "decree-ui",
 	"private": true,
-	"version": "0.2.0-alpha.1",
+	"version": "0.2.0-alpha.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",


### PR DESCRIPTION
Bump to v0.2.0-alpha.2 to publish the admin UI fixes from #122 (scroll + themed scrollbar #121, tenant combobox, tenant-not-found fallback). Tag-only release follows on merge; `publish.yml` builds and pushes the GHCR image.

Release plumbing — no functional change.