### PR TITLE
feat(e2e): add PR preview deploys and tenant-switch smoke test

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,96 @@
+name: PR Preview
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  deploy:
+    name: Deploy preview
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build with PR base path
+        run: npm run build -- --base=/decree-ui/pr-${{ github.event.number }}/
+
+      - name: SPA fallback for client-side routes
+        run: cp dist/index.html dist/404.html
+
+      - name: Deploy to gh-pages
+        # peaceiris/actions-gh-pages@v4.1.0
+        uses: peaceiris/actions-gh-pages@47f197a2200bb9de68ba5f48fad1c088eb1c4a32
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          destination_dir: pr-${{ github.event.number }}
+          keep_files: true
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const url = `https://opendecree.github.io/decree-ui/pr-${context.issue.number}/`;
+            const marker = "<!-- pr-preview-url -->";
+            const body = `${marker}\n🔍 Preview deployed: ${url}\n\n_Backend API is not available in this preview — use it to review layout, styling, and static screens. Built from ${context.sha.substring(0, 7)}._`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((c) => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+  cleanup:
+    name: Remove preview
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v7
+        with:
+          ref: gh-pages
+          persist-credentials: true
+
+      - name: Remove PR preview directory
+        run: |
+          if [ -d "pr-${{ github.event.number }}" ]; then
+            git rm -r "pr-${{ github.event.number }}"
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git commit -m "chore: remove preview for PR #${{ github.event.number }}"
+            git push
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ dist-ssr
 *.local
 openapi3.json
 coverage
+test-results
+playwright-report
 
 # Editor directories and files
 .vscode/*

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -61,6 +61,45 @@ test("tenant config page loads", async ({ page, request }) => {
 	await expect(page.getByTestId("config-editor")).toBeVisible();
 });
 
+test("tenant switch shows the selected tenant's config", async ({ page, request }) => {
+	const yamlB64 = Buffer.from(
+		"spec_version: v1\nname: e2e-switch\nfields:\n  y:\n    type: string",
+	).toString("base64");
+
+	const importRes = await request.post(`${API_URL}/v1/schemas/import`, {
+		headers: { ...AUTH_HEADERS, "content-type": "application/json" },
+		data: { yamlContent: yamlB64, autoPublish: true },
+	});
+	expect(importRes.ok()).toBeTruthy();
+	const { schema } = await importRes.json();
+
+	const tenantA = await request.post(`${API_URL}/v1/tenants`, {
+		headers: { ...AUTH_HEADERS, "content-type": "application/json" },
+		data: { name: "e2e-switch-a", schemaId: schema.id, schemaVersion: 1 },
+	});
+	expect(tenantA.ok()).toBeTruthy();
+	const { tenant: tenantAData } = await tenantA.json();
+
+	const tenantB = await request.post(`${API_URL}/v1/tenants`, {
+		headers: { ...AUTH_HEADERS, "content-type": "application/json" },
+		data: { name: "e2e-switch-b", schemaId: schema.id, schemaVersion: 1 },
+	});
+	expect(tenantB.ok()).toBeTruthy();
+	const { tenant: tenantBData } = await tenantB.json();
+
+	await page.goto("/tenants");
+	await expect(page.getByTestId("tenant-list-page")).toBeVisible();
+
+	await page.getByRole("link", { name: "e2e-switch-a" }).click();
+	await expect(page.getByTestId("config-editor")).toBeVisible();
+	await expect(page).toHaveURL(new RegExp(`/tenants/${tenantAData.id}$`));
+
+	await page.goto("/tenants");
+	await page.getByRole("link", { name: "e2e-switch-b" }).click();
+	await expect(page.getByTestId("config-editor")).toBeVisible();
+	await expect(page).toHaveURL(new RegExp(`/tenants/${tenantBData.id}$`));
+});
+
 test("API calls succeed through nginx proxy", async ({ page }) => {
 	await page.goto("/schemas");
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,7 +23,7 @@ document.documentElement.classList.toggle("dark", prefersDark);
 // biome-ignore lint/style/noNonNullAssertion: root element guaranteed by index.html
 createRoot(document.getElementById("root")!).render(
 	<StrictMode>
-		<BrowserRouter>
+		<BrowserRouter basename={import.meta.env.BASE_URL}>
 			<App />
 		</BrowserRouter>
 	</StrictMode>,


### PR DESCRIPTION
## Summary
- Closes the remaining acceptance criteria on #24: per-PR GitHub Pages preview deploys with an auto-commented (and self-updating) preview URL, plus a closed-PR cleanup job.
- Adds the missing tenant-switch e2e smoke test (create two tenants, navigate into each one's config editor, assert the editor reflects the selected tenant).
- Sets `BrowserRouter`'s `basename` from `import.meta.env.BASE_URL` so client-side routing works under the preview's `/decree-ui/pr-<n>/` subpath.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (435 tests passing)
- [x] `npm run build -- --base=/decree-ui/pr-123/` (verifies subpath build)
- [x] `npx playwright test` against the docker-compose stack (7/7 passing, including the new tenant-switch case)
- [ ] First PR run confirms the preview deploy + PR comment + cleanup-on-close flow end to end (GitHub Pages needs enabling on this repo once the `gh-pages` branch exists from this PR's first run)

Closes #24