### PR TITLE
chore(deps): ignore typescript major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # openapi-typescript@7.13.0 peer dep caps at typescript ^5.x; no TS7-compat release yet
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary
- Dependabot opened PR #134 bumping `typescript` from 5.9.3 to 7.0.2, but `openapi-typescript@7.13.0`'s peer dependency caps at `typescript@^5.x`, so `npm ci` fails with an ERESOLVE conflict and every CI job goes red.
- No release of `openapi-typescript` supports TypeScript 7 yet (latest published is 7.13.0, which is already what's installed), so there is no upgrade path available today.
- Ignore semver-major bumps for `typescript` specifically in Dependabot config, mirroring the same fix applied in decree-typescript#149. Minor and patch bumps are unaffected.

## Test plan
- [x] Confirmed PR #134's CI failure logs show the exact ERESOLVE conflict (typescript 7.0.2 vs openapi-typescript's `^5.x` peer dep)
- [x] Closed PR #134 with an explanatory comment
- [x] Verified no openapi-typescript release supports TypeScript 7